### PR TITLE
Update the README examples with corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ jobs:
 
 ### Enabling auto-merge
 
-If you are using [the auto-merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) feature on your repository,
-you can set up an action that will mark Dependabot PRs to merge once CI and other [branch protection](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule) conditions are met.
+If you are using [the auto-merge feature](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) on your repository,
+you can set up an action that will enable Dependabot PRs to merge once CI and other [branch protection rules](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule) are met.
 
 For example, if you want to automatically merge all patch updates to Rails:
 


### PR DESCRIPTION
Corrections to the README examples after some initial testing of the action.

The `permissions` clauses have been updated to reflect the explicitly required permissions for each example. Public repositories have permissive defaults for some of these, so the examples err on the side of an internal or private repository.
