### PR TITLE
Log the metadata outputs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13421,13 +13421,20 @@ const UPDATE_TYPES_PRIORITY = [
     'version-update:semver-patch'
 ];
 function set(updatedDependencies) {
-    core.info(`Outputting metadata for ${pluralize_default()('updated dependency', updatedDependencies.length, true)}`);
-    core.setOutput('updated-dependencies-json', updatedDependencies);
-    core.setOutput('dependency-names', updatedDependencies.map(dependency => {
+    const dependencyNames = updatedDependencies.map(dependency => {
         return dependency.dependencyName;
-    }).join(', '));
-    core.setOutput('dependency-type', maxDependencyTypes(updatedDependencies));
-    core.setOutput('update-type', maxSemver(updatedDependencies));
+    }).join(', ');
+    const dependencyType = maxDependencyTypes(updatedDependencies);
+    const updateType = maxSemver(updatedDependencies);
+    core.startGroup(`Outputting metadata for ${pluralize_default()('updated dependency', updatedDependencies.length, true)}`);
+    core.info(`outputs.dependency-names: ${dependencyNames}`);
+    core.info(`outputs.dependency-type: ${dependencyType}`);
+    core.info(`outputs.update-type: ${updateType}`);
+    core.endGroup();
+    core.setOutput('updated-dependencies-json', updatedDependencies);
+    core.setOutput('dependency-names', dependencyNames);
+    core.setOutput('dependency-type', dependencyType);
+    core.setOutput('update-type', updateType);
 }
 function maxDependencyTypes(updatedDependencies) {
     const dependencyTypes = updatedDependencies.reduce(function (dependencyTypes, dependency) {
@@ -13473,7 +13480,7 @@ function run() {
         const commitMessage = yield getMessage(githubClient, github.context);
         if (commitMessage) {
             // Parse metadata
-            core.info('Parsing Dependabot metadata/');
+            core.info('Parsing Dependabot metadata');
             const updatedDependencies = parse(commitMessage);
             if (updatedDependencies.length > 0) {
                 set(updatedDependencies);

--- a/src/dependabot/output.test.ts
+++ b/src/dependabot/output.test.ts
@@ -4,8 +4,9 @@ import * as Output from './output'
 beforeEach(() => {
   jest.restoreAllMocks()
 
-  jest.spyOn(core, 'setOutput').mockImplementation(jest.fn())
   jest.spyOn(core, 'info').mockImplementation(jest.fn())
+  jest.spyOn(core, 'setOutput').mockImplementation(jest.fn())
+  jest.spyOn(core, 'startGroup').mockImplementation(jest.fn())
 })
 
 test('when given a single dependency it sets its values', async () => {
@@ -19,7 +20,7 @@ test('when given a single dependency it sets its values', async () => {
 
   Output.set(updatedDependencies)
 
-  expect(core.info).toHaveBeenCalledWith(
+  expect(core.startGroup).toHaveBeenCalledWith(
     expect.stringContaining('Outputting metadata for 1 updated dependency')
   )
 
@@ -74,7 +75,7 @@ test('when the dependency has no update type', async () => {
 
   Output.set(updatedDependencies)
 
-  expect(core.info).toHaveBeenCalledWith(
+  expect(core.startGroup).toHaveBeenCalledWith(
     expect.stringContaining('Outputting metadata for 1 updated dependency')
   )
 

--- a/src/dependabot/output.ts
+++ b/src/dependabot/output.ts
@@ -14,15 +14,22 @@ const UPDATE_TYPES_PRIORITY = [
 ]
 
 export function set (updatedDependencies: Array<updatedDependency>): void {
-  core.info(`Outputting metadata for ${Pluralize('updated dependency', updatedDependencies.length, true)}`)
+  const dependencyNames = updatedDependencies.map(dependency => {
+    return dependency.dependencyName
+  }).join(', ');
+  const dependencyType = maxDependencyTypes(updatedDependencies);
+  const updateType = maxSemver(updatedDependencies);
+
+  core.startGroup(`Outputting metadata for ${Pluralize('updated dependency', updatedDependencies.length, true)}`);
+  core.info(`outputs.dependency-names: ${dependencyNames}`);
+  core.info(`outputs.dependency-type: ${dependencyType}`);
+  core.info(`outputs.update-type: ${updateType}`);
+  core.endGroup();
 
   core.setOutput('updated-dependencies-json', updatedDependencies)
-
-  core.setOutput('dependency-names', updatedDependencies.map(dependency => {
-    return dependency.dependencyName
-  }).join(', '))
-  core.setOutput('dependency-type', maxDependencyTypes(updatedDependencies))
-  core.setOutput('update-type', maxSemver(updatedDependencies))
+  core.setOutput('dependency-names', dependencyNames);
+  core.setOutput('dependency-type', dependencyType);
+  core.setOutput('update-type', updateType);
 }
 
 function maxDependencyTypes (updatedDependencies: Array<updatedDependency>): string {

--- a/src/dependabot/output.ts
+++ b/src/dependabot/output.ts
@@ -16,20 +16,20 @@ const UPDATE_TYPES_PRIORITY = [
 export function set (updatedDependencies: Array<updatedDependency>): void {
   const dependencyNames = updatedDependencies.map(dependency => {
     return dependency.dependencyName
-  }).join(', ');
-  const dependencyType = maxDependencyTypes(updatedDependencies);
-  const updateType = maxSemver(updatedDependencies);
+  }).join(', ')
+  const dependencyType = maxDependencyTypes(updatedDependencies)
+  const updateType = maxSemver(updatedDependencies)
 
-  core.startGroup(`Outputting metadata for ${Pluralize('updated dependency', updatedDependencies.length, true)}`);
-  core.info(`outputs.dependency-names: ${dependencyNames}`);
-  core.info(`outputs.dependency-type: ${dependencyType}`);
-  core.info(`outputs.update-type: ${updateType}`);
-  core.endGroup();
+  core.startGroup(`Outputting metadata for ${Pluralize('updated dependency', updatedDependencies.length, true)}`)
+  core.info(`outputs.dependency-names: ${dependencyNames}`)
+  core.info(`outputs.dependency-type: ${dependencyType}`)
+  core.info(`outputs.update-type: ${updateType}`)
+  core.endGroup()
 
   core.setOutput('updated-dependencies-json', updatedDependencies)
-  core.setOutput('dependency-names', dependencyNames);
-  core.setOutput('dependency-type', dependencyType);
-  core.setOutput('update-type', updateType);
+  core.setOutput('dependency-names', dependencyNames)
+  core.setOutput('dependency-type', dependencyType)
+  core.setOutput('update-type', updateType)
 }
 
 function maxDependencyTypes (updatedDependencies: Array<updatedDependency>): string {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -5,8 +5,9 @@ import * as dependabotCommits from './dependabot/verified_commits'
 beforeEach(() => {
   jest.restoreAllMocks()
 
-  jest.spyOn(core, 'setFailed').mockImplementation(jest.fn())
   jest.spyOn(core, 'info').mockImplementation(jest.fn())
+  jest.spyOn(core, 'setFailed').mockImplementation(jest.fn())
+  jest.spyOn(core, 'startGroup').mockImplementation(jest.fn())
 })
 
 test('it early exits with an error if github-token is not set', async () => {
@@ -72,7 +73,7 @@ test('it sets the updated dependency as an output for subsequent actions', async
 
   await run()
 
-  expect(core.info).toHaveBeenCalledWith(
+  expect(core.startGroup).toHaveBeenCalledWith(
     expect.stringContaining('Outputting metadata for 1 updated dependency')
   )
 
@@ -119,7 +120,7 @@ test('if there are multiple dependencies, it summarizes them', async () => {
 
   await run()
 
-  expect(core.info).toHaveBeenCalledWith(
+  expect(core.startGroup).toHaveBeenCalledWith(
     expect.stringContaining('Outputting metadata for 2 updated dependencies')
   )
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ export async function run (): Promise<void> {
 
   if (commitMessage) {
     // Parse metadata
-    core.info('Parsing Dependabot metadata/')
+    core.info('Parsing Dependabot metadata')
 
     const updatedDependencies = updateMetadata.parse(commitMessage)
 


### PR DESCRIPTION
Adding a log group around `Outputting metadata for updated dependencies`
and logging the metadata outputs in there.

I found myself reaching for the metadata output in the logs.
It should make it easier to debug an action that's not matching a pr.