### PR TITLE
Ensure errors result in the Action failing out of later steps

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -144,3 +144,16 @@ test('if there are multiple dependencies, it summarizes them', async () => {
   expect(core.setOutput).toBeCalledWith('dependency-type', 'direct:production')
   expect(core.setOutput).toBeCalledWith('update-type', 'version-update:semver-major')
 })
+
+test("it sets the action to failed if there is an unexpected exception", async () => {
+  jest.spyOn(core, 'getInput').mockReturnValue('mock-token')
+  jest.spyOn(dependabotCommits, 'getMessage').mockImplementation(jest.fn(
+    () => Promise.reject( new Error("Something bad happened!") )
+  ))
+
+  await run()
+
+  expect(core.setFailed).toHaveBeenCalledWith(
+    expect.stringContaining('Something bad happened!')
+  )
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
+import { RequestError } from '@octokit/request-error'
 import * as verifiedCommits from './dependabot/verified_commits'
 import * as updateMetadata from './dependabot/update_metadata'
 import * as output from './dependabot/output'
@@ -37,7 +38,11 @@ export async function run (): Promise<void> {
       core.setFailed('PR is not from Dependabot, nothing to do.')
     }
   } catch (error) {
-    core.setFailed(error.message);
+    if (error instanceof RequestError) {
+      core.setFailed(`Api Error: (${error.status}) ${error.message}`)
+      return
+    }
+    core.setFailed(error.message)
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,24 +16,28 @@ export async function run (): Promise<void> {
     return
   }
 
-  const githubClient = github.getOctokit(token)
+  try {
+    const githubClient = github.getOctokit(token)
 
-  // Validate the job
-  const commitMessage = await verifiedCommits.getMessage(githubClient, github.context)
+    // Validate the job
+    const commitMessage = await verifiedCommits.getMessage(githubClient, github.context)
 
-  if (commitMessage) {
-    // Parse metadata
-    core.info('Parsing Dependabot metadata')
+    if (commitMessage) {
+      // Parse metadata
+      core.info('Parsing Dependabot metadata')
 
-    const updatedDependencies = updateMetadata.parse(commitMessage)
+      const updatedDependencies = updateMetadata.parse(commitMessage)
 
-    if (updatedDependencies.length > 0) {
-      output.set(updatedDependencies)
+      if (updatedDependencies.length > 0) {
+        output.set(updatedDependencies)
+      } else {
+        core.setFailed('PR does not contain metadata, nothing to do.')
+      }
     } else {
-      core.setFailed('PR does not contain metadata, nothing to do.')
+      core.setFailed('PR is not from Dependabot, nothing to do.')
     }
-  } else {
-    core.setFailed('PR is not from Dependabot, nothing to do.')
+  } catch (error) {
+    core.setFailed(error.message);
   }
 }
 


### PR DESCRIPTION
Fixes #18 

Catch _any_ errors within the code into a `setFailed` clause, with a specific handler for API errors for clarity.