### PR TITLE
Enable auto-merge ourselves

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,20 @@
+name: Dependabot auto-merge
+on: pull_request_target
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch metadata
+        id: metadata
+        uses: ./
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Use the action version in `main` to enable auto-merging on our own Dependabot PRs so they just need ✅  from a reviewer in future and provide integration testing of the `main` branch.

<details><summary>Obligatory self-testing reference</summary>

![testing](https://user-images.githubusercontent.com/896971/120999423-fed44e80-c780-11eb-8cbe-84a49d67cdc6.jpg)

</details>

