### PR TITLE
Default github-token

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,8 +14,6 @@ jobs:
       - name: Fetch metadata
         id: metadata
         uses: ./
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Auto-merge
         run: gh pr merge --auto --merge "$PR_URL"

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ jobs:
       id: dependabot-metadata
       uses: dependabot/fetch-metadata@v1.1.1
       with:
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
         alert-lookup: true
 ```
 
 Supported inputs are:
 
-- `github-token` (REQUIRED string)
+- `github-token` (string)
   - The `GITHUB_TOKEN` secret
+  - Defaults to `${{ github.token }}`
 - `alert-lookup` (boolean)
   - If `true`, then call populate the `alert-state`, `ghsa-id` and `cvss` outputs.
   - Defaults to `false`
@@ -88,8 +88,6 @@ jobs:
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v1.1.1
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:
@@ -118,8 +116,6 @@ jobs:
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v1.1.1
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         if: ${{contains(steps.dependabot-metadata.outputs.dependency-names, 'rails') && steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch'}}
         run: gh pr merge --auto --merge "$PR_URL"
@@ -149,8 +145,6 @@ jobs:
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v1.1.1
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Add a label for all production dependencies
         if: ${{ steps.dependabot-metadata.outputs.dependency-type == 'direct:production' }}
         run: gh pr edit "$PR_URL" --add-label "production"

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'If true, then call populate the `alert-state`, `ghsa-id` and `cvss` outputs'
   github-token:
     description: 'The GITHUB_TOKEN secret'
-    required: true
+    default: ${{ github.token }}
 outputs:
   dependency-names:
     description: 'A comma-separated list of all package names updated.'


### PR DESCRIPTION
Would it make sense for the `github-token` [default value](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_iddefault) to be `${{ github.token }}`, consistent with [actions/checkout](https://github.com/actions/checkout/blob/afe4af09a72596f47d806ee5f8b2674ec07fdc73/action.yml#L24)?