### PR TITLE
V1.2.1 release notes

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+usage() { echo "Usage: $0 -p [major | minor | patch]" 1>&2; exit 1; }
+
+while getopts "p:" o; do
+  case "${o}" in
+    p)
+      patch_level=${OPTARG}
+      (( patch_level == 'major' || patch_level == 'minor' || patch_level == 'patch'))
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+echo "$patch_level"
+
+if [[ -z "${patch_level}" ]]; then
+  usage
+fi
+
+new_version=$(npm version "${patch_level}" --no-git-tag-version)
+git checkout -b "${new_version}"-release-notes
+git add package.json package-lock.json
+git commit -m "${new_version}"
+
+echo "Branch prepared for ${new_version}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-pull-request-action",
-      "version": "1.1.1",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "Parse Dependabot commit metadata to automate PR handling",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Highlights:

- Check the PR author instead of the Action Actor so failed `fetch-metadata` workflows can be retried, thanks @mwaddell!
- Catch up on our dependency updates 😅 

## What's Changed
* Check PR Author instead of Action Actor by @mwaddell in https://github.com/dependabot/fetch-metadata/pull/137
* Updated README to list supported `dependency-type` values by @mwaddell in https://github.com/dependabot/fetch-metadata/pull/145
* Bump yargs from 17.0.1 to 17.3.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/126
* Bump eslint-plugin-import from 2.23.4 to 2.25.4 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/129
* Bump ts-node from 10.1.0 to 10.5.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/142
* Bump @types/node from 16.4.10 to 17.0.19 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/147
* Bump @typescript-eslint/parser from 4.29.0 to 4.33.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/149
* Bump @types/jest from 26.0.24 to 27.4.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/151
* Bump @vercel/ncc from 0.29.0 to 0.33.3 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/148
* Bump @typescript-eslint/eslint-plugin from 4.29.0 to 4.33.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/152
* Bump @types/yargs from 17.0.2 to 17.0.8 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/153
* Bump nock from 13.1.1 to 13.2.4 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/154
* Bump tmpl from 1.0.4 to 1.0.5 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/160
* Bump node-fetch from 2.6.1 to 2.6.7 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/159
* Bump eslint-plugin-promise from 5.1.0 to 6.0.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/158
* Bump dotenv from 10.0.0 to 16.0.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/156
* Bump @actions/core from 1.4.0 to 1.6.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/155
* Bump typescript from 4.3.5 to 4.5.5 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/157
* Bump eslint from 7.32.0 to 8.9.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/150

**Full Changelog**: https://github.com/dependabot/fetch-metadata/compare/v1.2.0...v1.2.1