### PR TITLE
Execute automerges using a PAT

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,4 +21,4 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTOMERGE_PAT }}


### PR DESCRIPTION
Ironically, this repository itself runs into the issue whereby API calls performed by `dependabot[bot]` inside Actions can't trigger downstream workflows so our auto merge commits [don't trigger CI currently](https://github.com/dependabot/fetch-metadata/commit/54c7e6cb13d04ff08e366fd57f08e2026263e63a).

This PR follows our own advice on how to workaround the problem with merges. I'll update the README once I've verified this works as intended.