### PR TITLE
Updated `bump-version` to update README.md as well

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -22,7 +22,8 @@ fi
 
 new_version=$(npm version "${patch_level}" --no-git-tag-version)
 git checkout -b "${new_version}"-release-notes
-git add package.json package-lock.json
+sed -i "s|dependabot/fetch-metadata@v[0-9.]*|dependabot/fetch-metadata@${new_version}|g" README.md
+git add package.json package-lock.json README.md
 git commit -m "${new_version}"
 
 echo "Branch prepared for ${new_version}"


### PR DESCRIPTION
I noticed in #161 that the `bump-version` script does not update the README.md file.  This PR addresses that.