### PR TITLE
Use github.actor for validating Dependabot auto-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
     # Checking the author will prevent your Action run failing on non-Dependabot PRs
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
@@ -113,7 +113,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
@@ -144,7 +144,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata


### PR DESCRIPTION
Using the user associated to the original PR creation prevents any other user from adding additional commits on top of a Dependabot PR as the action will fail during the fetch-metadata step.

Here's what it looks like for an auto-approve process using `github.event.pull_request.user.login == 'dependabot[bot]'`:

<img width="786" alt="image" src="https://user-images.githubusercontent.com/684275/155820082-9b9ad8a7-a42f-4135-ae0b-c6d2a3229224.png">
