### PR TITLE
Allow fetch-metadata to run on a PR even if it has additional commits…

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9152,13 +9152,10 @@ function getMessage(client, context) {
             repo: context.repo.repo,
             pull_number: pr.number
         });
-        if (commits.length > 1) {
-            warnOtherCommits();
-            return false;
-        }
         const { commit, author } = commits[0];
         if ((author === null || author === void 0 ? void 0 : author.login) !== DEPENDABOT_LOGIN) {
-            warnOtherCommits();
+            // TODO: Promote to setFailed
+            core.warning('It looks like this PR was not created by Dependabot, refusing to proceed.');
             return false;
         }
         if (!((_a = commit.verification) === null || _a === void 0 ? void 0 : _a.verified)) {
@@ -9170,11 +9167,6 @@ function getMessage(client, context) {
     });
 }
 exports.getMessage = getMessage;
-function warnOtherCommits() {
-    core.warning("It looks like this PR has contains commits that aren't part of a Dependabot update. " +
-        "Try using '@dependabot rebase' to remove merge commits or '@dependabot recreate' to remove " +
-        'any non-Dependabot changes.');
-}
 function getAlert(name, version, directory, client, context) {
     var _a, _b, _c, _d, _e;
     return __awaiter(this, void 0, void 0, function* () {

--- a/src/dependabot/verified_commits.test.ts
+++ b/src/dependabot/verified_commits.test.ts
@@ -33,28 +33,6 @@ test('it returns false for an event triggered by someone other than Dependabot',
   )
 })
 
-test('it returns false if there is more than 1 commit', async () => {
-  nock('https://api.github.com').get('/repos/dependabot/dependabot/pulls/101/commits')
-    .reply(200, [
-      {
-        commit: {
-          message: 'Bump lodash from 1.0.0 to 2.0.0'
-        }
-      },
-      {
-        commit: {
-          message: 'Add some more things.'
-        }
-      }
-    ])
-
-  expect(await getMessage(mockGitHubClient, mockGitHubPullContext())).toBe(false)
-
-  expect(core.warning).toHaveBeenCalledWith(
-    expect.stringContaining("It looks like this PR has contains commits that aren't part of a Dependabot update.")
-  )
-})
-
 test('it returns false if the commit was authored by someone other than Dependabot', async () => {
   nock('https://api.github.com').get('/repos/dependabot/dependabot/pulls/101/commits')
     .reply(200, [
@@ -71,7 +49,7 @@ test('it returns false if the commit was authored by someone other than Dependab
   expect(await getMessage(mockGitHubClient, mockGitHubPullContext())).toBe(false)
 
   expect(core.warning).toHaveBeenCalledWith(
-    expect.stringContaining("It looks like this PR has contains commits that aren't part of a Dependabot update.")
+    expect.stringContaining("It looks like this PR was not created by Dependabot, refusing to proceed.")
   )
 })
 
@@ -123,6 +101,11 @@ test('it returns the commit message for a PR authored exclusively by Dependabot 
           verification: {
             verified: true
           }
+        }
+      },
+      {
+        commit: {
+          message: 'Add some more things.'
         }
       }
     ])

--- a/src/dependabot/verified_commits.test.ts
+++ b/src/dependabot/verified_commits.test.ts
@@ -49,7 +49,7 @@ test('it returns false if the commit was authored by someone other than Dependab
   expect(await getMessage(mockGitHubClient, mockGitHubPullContext())).toBe(false)
 
   expect(core.warning).toHaveBeenCalledWith(
-    expect.stringContaining("It looks like this PR was not created by Dependabot, refusing to proceed.")
+    expect.stringContaining('It looks like this PR was not created by Dependabot, refusing to proceed.')
   )
 })
 

--- a/src/dependabot/verified_commits.ts
+++ b/src/dependabot/verified_commits.ts
@@ -32,15 +32,13 @@ export async function getMessage (client: InstanceType<typeof GitHub>, context: 
     pull_number: pr.number
   })
 
-  if (commits.length > 1) {
-    warnOtherCommits()
-    return false
-  }
-
   const { commit, author } = commits[0]
 
   if (author?.login !== DEPENDABOT_LOGIN) {
-    warnOtherCommits()
+    // TODO: Promote to setFailed
+    core.warning(
+      'It looks like this PR was not created by Dependabot, refusing to proceed.'
+    )
     return false
   }
 
@@ -53,14 +51,6 @@ export async function getMessage (client: InstanceType<typeof GitHub>, context: 
   }
 
   return commit.message
-}
-
-function warnOtherCommits (): void {
-  core.warning(
-    "It looks like this PR has contains commits that aren't part of a Dependabot update. " +
-      "Try using '@dependabot rebase' to remove merge commits or '@dependabot recreate' to remove " +
-        'any non-Dependabot changes.'
-  )
 }
 
 export async function getAlert (name: string, version: string, directory: string, client: InstanceType<typeof GitHub>, context: Context): Promise<dependencyAlert> {


### PR DESCRIPTION
…, as long as the 0th one was added by dependabot and is verified.