### PR TITLE
V1.3.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Extract information about the dependencies being updated by a Dependabot-generat
 
 ## Usage instructions
 
-Create a workflow file that contains a step that uses: `dependabot/fetch-metadata@v1.2.1`, e.g.
+Create a workflow file that contains a step that uses: `dependabot/fetch-metadata@v1.3.0`, e.g.
 
 ```yaml
 -- .github/workflows/dependabot-prs.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Fetch Dependabot metadata
       id: dependabot-metadata
-      uses: dependabot/fetch-metadata@v1.2.1
+      uses: dependabot/fetch-metadata@v1.3.0
       with:
         alert-lookup: true
         compat-lookup: true
@@ -93,7 +93,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.2.1
+        uses: dependabot/fetch-metadata@v1.3.0
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.2.1
+        uses: dependabot/fetch-metadata@v1.3.0
       - name: Enable auto-merge for Dependabot PRs
         if: ${{contains(steps.dependabot-metadata.outputs.dependency-names, 'rails') && steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch'}}
         run: gh pr merge --auto --merge "$PR_URL"
@@ -150,7 +150,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.2.1
+        uses: dependabot/fetch-metadata@v1.3.0
       - name: Add a label for all production dependencies
         if: ${{ steps.dependabot-metadata.outputs.dependency-type == 'direct:production' }}
         run: gh pr edit "$PR_URL" --add-label "production"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-pull-request-action",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Parse Dependabot commit metadata to automate PR handling",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Highlights

### 🆕  Fetch additional metadata about Dependabot commits

You can now optionally enable API lookups within the Action to retrieve extra information about Dependabot PRs.

Example:
```yaml
-- .github/workflows/dependabot-prs.yml
name: Dependabot Pull Request
on: pull_request_target
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
    - name: Fetch Dependabot metadata
      id: dependabot-metadata
      uses: dependabot/fetch-metadata@v1.3.0
      with:
        alert-lookup: true
        compat-lookup: true
```

The flags enable the following new outputs:
- `steps.dependabot-metadata.outputs.alert-state`
  - If this PR is associated with a security alert and `alert-lookup` is `true`, this contains the current state of that alert (OPEN, FIXED or DISMISSED).
- `steps.dependabot-metadata.outputs.ghsa-id`
  - If this PR is associated with a security alert and `alert-lookup` is `true`, this contains the GHSA-ID of that alert.
- `steps.dependabot-metadata.outputs.cvss`
  - If this PR is associated with a security alert and `alert-lookup` is `true`, this contains the CVSS value of that alert (otherwise it contains 0).
- `steps.dependabot-metadata.outputs.compatibility-score`
  - If this PR has a known compatibility score and `compat-lookup` is `true`, this contains the compatibility score (otherwise it contains 0).

Many thanks to @mwaddell for contributing these additional flags 🥇 

### The Action no longer fails if other commits are present

We received feedback at this change was highly obtrusive and blocking common workflows that merging in the target branch. Following on from changes in 1.2.1 to make it easier for a user to re-run failed workflows this friction was much more obvious.

Thanks for the feedback, and thanks @mwaddell for contributing the change.

### The Action defaults to using the GITHUB_TOKEN

This makes us consistent with other GitHub Actions such as `actions/checkout` in using the baseline token provided to the workflow. Since the Action doesn't have any features which require write scopes this defaulting is adequate for all use cases.

Thanks @jablko for contributing this change 🏆 

## What's Changed
* Flag security alerts and pass versions through by @mwaddell in https://github.com/dependabot/fetch-metadata/pull/144
* Updated `bump-version` to update README.md as well by @mwaddell in https://github.com/dependabot/fetch-metadata/pull/163
* Updated README to reference correct version by @mwaddell in https://github.com/dependabot/fetch-metadata/pull/165
* Allow fetch-metadata to run on a PR even if it has additional commits… by @mwaddell in https://github.com/dependabot/fetch-metadata/pull/166
* Default github-token by @jablko in https://github.com/dependabot/fetch-metadata/pull/83
* Return compatibility score by @mwaddell in https://github.com/dependabot/fetch-metadata/pull/146

## New Contributors
* @jablko made their first contribution in https://github.com/dependabot/fetch-metadata/pull/83

**Full Changelog**: https://github.com/dependabot/fetch-metadata/compare/v1.2.1...v1.3.0