### PR TITLE
Add an OSX workaround for sed in bump-version

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -22,7 +22,8 @@ fi
 
 new_version=$(npm version "${patch_level}" --no-git-tag-version)
 git checkout -b "${new_version}"-release-notes
-sed -i "s|dependabot/fetch-metadata@v[0-9.]*|dependabot/fetch-metadata@${new_version}|g" README.md
+# NOTE: For OSX compatability, -i must have an empty string argument passed
+sed -i "" "s|dependabot/fetch-metadata@v[0-9.]*|dependabot/fetch-metadata@v${new_version}|g" "README.md"
 git add package.json package-lock.json README.md
 git commit -m "${new_version}"
 


### PR DESCRIPTION
OSX doesn't tolerate `-i` without passing a blank argument. I _think_ this is ok on 'nix but I could use a double-check.