### PR TITLE
Added flag if "Maintainer changes" appears in the PR body

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8959,6 +8959,7 @@ function set(updatedDependencies) {
     const prevVersion = firstDependency === null || firstDependency === void 0 ? void 0 : firstDependency.prevVersion;
     const newVersion = firstDependency === null || firstDependency === void 0 ? void 0 : firstDependency.newVersion;
     const compatScore = firstDependency === null || firstDependency === void 0 ? void 0 : firstDependency.compatScore;
+    const maintChange = firstDependency === null || firstDependency === void 0 ? void 0 : firstDependency.maintChange;
     const alertState = firstDependency === null || firstDependency === void 0 ? void 0 : firstDependency.alertState;
     const ghsaId = firstDependency === null || firstDependency === void 0 ? void 0 : firstDependency.ghsaId;
     const cvss = firstDependency === null || firstDependency === void 0 ? void 0 : firstDependency.cvss;
@@ -8972,6 +8973,7 @@ function set(updatedDependencies) {
     core.info(`outputs.previous-version: ${prevVersion}`);
     core.info(`outputs.new-version: ${newVersion}`);
     core.info(`outputs.compatibility-score: ${compatScore}`);
+    core.info(`outputs.maintainer-change: ${maintChange}`);
     core.info(`outputs.alert-state: ${alertState}`);
     core.info(`outputs.ghsa-id: ${ghsaId}`);
     core.info(`outputs.cvss: ${cvss}`);
@@ -8986,6 +8988,7 @@ function set(updatedDependencies) {
     core.setOutput('previous-version', prevVersion);
     core.setOutput('new-version', newVersion);
     core.setOutput('compatibility-score', compatScore);
+    core.setOutput('maintainer-change', maintChange);
     core.setOutput('alert-state', alertState);
     core.setOutput('ghsa-id', ghsaId);
     core.setOutput('cvss', cvss);
@@ -9045,11 +9048,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parse = void 0;
 const YAML = __importStar(__nccwpck_require__(4603));
-function parse(commitMessage, branchName, mainBranch, lookup, getScore) {
+function parse(commitMessage, body, branchName, mainBranch, lookup, getScore) {
     var _a, _b, _c, _d;
     return __awaiter(this, void 0, void 0, function* () {
         const bumpFragment = commitMessage.match(/^Bumps .* from (?<from>\d[^ ]*) to (?<to>\d[^ ]*)\.$/m);
         const yamlFragment = commitMessage.match(/^-{3}\n(?<dependencies>[\S|\s]*?)\n^\.{3}\n/m);
+        const newMaintainer = !!body.match(/Maintainer changes/m);
         const lookupFn = lookup !== null && lookup !== void 0 ? lookup : (() => Promise.resolve({ alertState: '', ghsaId: '', cvss: 0 }));
         const scoreFn = getScore !== null && getScore !== void 0 ? getScore : (() => Promise.resolve(0));
         if ((yamlFragment === null || yamlFragment === void 0 ? void 0 : yamlFragment.groups) && branchName.startsWith('dependabot')) {
@@ -9064,7 +9068,7 @@ function parse(commitMessage, branchName, mainBranch, lookup, getScore) {
                     const dirname = `/${chunks.slice(2, -1 * (1 + (dependency['dependency-name'].match(/\//g) || []).length)).join(delim) || ''}`;
                     const lastVersion = index === 0 ? prev : '';
                     const nextVersion = index === 0 ? next : '';
-                    return Object.assign({ dependencyName: dependency['dependency-name'], dependencyType: dependency['dependency-type'], updateType: dependency['update-type'], directory: dirname, packageEcosystem: chunks[1], targetBranch: mainBranch, prevVersion: lastVersion, newVersion: nextVersion, compatScore: yield scoreFn(dependency['dependency-name'], lastVersion, nextVersion, chunks[1]) }, yield lookupFn(dependency['dependency-name'], lastVersion, dirname));
+                    return Object.assign({ dependencyName: dependency['dependency-name'], dependencyType: dependency['dependency-type'], updateType: dependency['update-type'], directory: dirname, packageEcosystem: chunks[1], targetBranch: mainBranch, prevVersion: lastVersion, newVersion: nextVersion, compatScore: yield scoreFn(dependency['dependency-name'], lastVersion, nextVersion, chunks[1]), maintChange: newMaintainer }, yield lookupFn(dependency['dependency-name'], lastVersion, dirname));
                 })));
             }
         }
@@ -9082,7 +9086,7 @@ exports.parse = parse;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getBranchNames = exports.parseNwo = void 0;
+exports.getBody = exports.getBranchNames = exports.parseNwo = void 0;
 function parseNwo(nwo) {
     const [owner, name] = nwo.split('/');
     if (!owner || !name) {
@@ -9096,6 +9100,11 @@ function getBranchNames(context) {
     return { headName: (pr === null || pr === void 0 ? void 0 : pr.head.ref) || '', baseName: pr === null || pr === void 0 ? void 0 : pr.base.ref };
 }
 exports.getBranchNames = getBranchNames;
+function getBody(context) {
+    const { pull_request: pr } = context.payload;
+    return (pr === null || pr === void 0 ? void 0 : pr.body) || '';
+}
+exports.getBody = getBody;
 
 
 /***/ }),
@@ -9290,6 +9299,7 @@ function run() {
             // Validate the job
             const commitMessage = yield verifiedCommits.getMessage(githubClient, github.context);
             const branchNames = util.getBranchNames(github.context);
+            const body = util.getBody(github.context);
             let alertLookup;
             if (core.getInput('alert-lookup')) {
                 alertLookup = (name, version, directory) => verifiedCommits.getAlert(name, version, directory, githubClient, github.context);
@@ -9298,7 +9308,7 @@ function run() {
             if (commitMessage) {
                 // Parse metadata
                 core.info('Parsing Dependabot metadata');
-                const updatedDependencies = yield updateMetadata.parse(commitMessage, branchNames.headName, branchNames.baseName, alertLookup, scoreLookup);
+                const updatedDependencies = yield updateMetadata.parse(commitMessage, body, branchNames.headName, branchNames.baseName, alertLookup, scoreLookup);
                 if (updatedDependencies.length > 0) {
                     output.set(updatedDependencies);
                 }

--- a/src/dependabot/output.test.ts
+++ b/src/dependabot/output.test.ts
@@ -19,6 +19,7 @@ const baseDependency = {
   prevVersion: '',
   newVersion: '',
   compatScore: 0,
+  maintChange: false,
   alertState: '',
   ghsaId: '',
   cvss: 0
@@ -36,6 +37,7 @@ test('when given a single dependency it sets its values', async () => {
       prevVersion: '1.0.2',
       newVersion: '1.1.3-beta',
       compatScore: 43,
+      maintChange: false,
       alertState: 'FIXED',
       ghsaId: 'VERY_LONG_ID',
       cvss: 4.6

--- a/src/dependabot/output.ts
+++ b/src/dependabot/output.ts
@@ -27,6 +27,7 @@ export function set (updatedDependencies: Array<updatedDependency>): void {
   const prevVersion = firstDependency?.prevVersion
   const newVersion = firstDependency?.newVersion
   const compatScore = firstDependency?.compatScore
+  const maintChange = firstDependency?.maintChange
   const alertState = firstDependency?.alertState
   const ghsaId = firstDependency?.ghsaId
   const cvss = firstDependency?.cvss
@@ -41,6 +42,7 @@ export function set (updatedDependencies: Array<updatedDependency>): void {
   core.info(`outputs.previous-version: ${prevVersion}`)
   core.info(`outputs.new-version: ${newVersion}`)
   core.info(`outputs.compatibility-score: ${compatScore}`)
+  core.info(`outputs.maintainer-change: ${maintChange}`)
   core.info(`outputs.alert-state: ${alertState}`)
   core.info(`outputs.ghsa-id: ${ghsaId}`)
   core.info(`outputs.cvss: ${cvss}`)
@@ -56,6 +58,7 @@ export function set (updatedDependencies: Array<updatedDependency>): void {
   core.setOutput('previous-version', prevVersion)
   core.setOutput('new-version', newVersion)
   core.setOutput('compatibility-score', compatScore)
+  core.setOutput('maintainer-change', maintChange)
   core.setOutput('alert-state', alertState)
   core.setOutput('ghsa-id', ghsaId)
   core.setOutput('cvss', cvss)

--- a/src/dependabot/update_metadata.test.ts
+++ b/src/dependabot/update_metadata.test.ts
@@ -3,7 +3,7 @@ import * as updateMetadata from './update_metadata'
 test('it returns an empty array for a blank string', async () => {
   const getAlert = async () => Promise.resolve({ alertState: 'DISMISSED', ghsaId: 'GHSA-III-BBB', cvss: 4.6 })
   const getScore = async () => Promise.resolve(43)
-  expect(updateMetadata.parse('', 'dependabot/nuget/coffee-rails', 'main', getAlert, getScore)).resolves.toEqual([])
+  expect(updateMetadata.parse('', '', 'dependabot/nuget/coffee-rails', 'main', getAlert, getScore)).resolves.toEqual([])
 })
 
 test('it returns an empty array for commit message with no dependabot yaml fragment', async () => {
@@ -16,7 +16,7 @@ test('it returns an empty array for commit message with no dependabot yaml fragm
 
   const getAlert = async () => Promise.resolve({ alertState: 'DISMISSED', ghsaId: 'GHSA-III-BBB', cvss: 4.6 })
   const getScore = async () => Promise.resolve(43)
-  expect(updateMetadata.parse(commitMessage, 'dependabot/nuget/coffee-rails', 'main', getAlert, getScore)).resolves.toEqual([])
+  expect(updateMetadata.parse(commitMessage, '', 'dependabot/nuget/coffee-rails', 'main', getAlert, getScore)).resolves.toEqual([])
 })
 
 test('it returns the updated dependency information when there is a yaml fragment', async () => {
@@ -34,10 +34,18 @@ test('it returns the updated dependency information when there is a yaml fragmen
     '...\n' +
     '\n' +
     'Signed-off-by: dependabot[bot] <support@github.com>'
+  const body =
+    'Bumps [coffee-rails](https://github.com/rails/coffee-rails) from 4.0.1 to 4.2.2.\n' +
+    '- [Release notes](https://github.com/rails/coffee-rails/releases)\n' +
+    '- [Changelog](https://github.com/rails/coffee-rails/blob/master/CHANGELOG.md)\n' +
+    '- [Commits](rails/coffee-rails@v4.0.1...v4.2.2)\n' +
+    '\n' +
+    'Maintainer changes:\n' +
+    'The maintainer changed!'
 
   const getAlert = async () => Promise.resolve({ alertState: 'DISMISSED', ghsaId: 'GHSA-III-BBB', cvss: 4.6 })
   const getScore = async () => Promise.resolve(43)
-  const updatedDependencies = await updateMetadata.parse(commitMessage, 'dependabot/nuget/coffee-rails', 'main', getAlert, getScore)
+  const updatedDependencies = await updateMetadata.parse(commitMessage, body, 'dependabot/nuget/coffee-rails', 'main', getAlert, getScore)
 
   expect(updatedDependencies).toHaveLength(1)
 
@@ -50,6 +58,7 @@ test('it returns the updated dependency information when there is a yaml fragmen
   expect(updatedDependencies[0].prevVersion).toEqual('4.0.1')
   expect(updatedDependencies[0].newVersion).toEqual('4.2.2')
   expect(updatedDependencies[0].compatScore).toEqual(43)
+  expect(updatedDependencies[0].maintChange).toEqual(true)
   expect(updatedDependencies[0].alertState).toEqual('DISMISSED')
   expect(updatedDependencies[0].ghsaId).toEqual('GHSA-III-BBB')
   expect(updatedDependencies[0].cvss).toEqual(4.6)
@@ -73,6 +82,13 @@ test('it supports multiple dependencies within a single fragment', async () => {
     '...\n' +
     '\n' +
     'Signed-off-by: dependabot[bot] <support@github.com>'
+  const body =
+    'Bumps [coffee-rails](https://github.com/rails/coffee-rails) from 4.0.1 to 4.2.2.\n' +
+    '- [Release notes](https://github.com/rails/coffee-rails/releases)\n' +
+    '- [Changelog](https://github.com/rails/coffee-rails/blob/master/CHANGELOG.md)\n' +
+    '- [Commits](rails/coffee-rails@v4.0.1...v4.2.2)\n' +
+    '\n' +
+    'Has the maintainer changed?'
 
   const getAlert = async (name: string) => {
     if (name === 'coffee-rails') {
@@ -90,7 +106,7 @@ test('it supports multiple dependencies within a single fragment', async () => {
     return Promise.resolve(0)
   }
 
-  const updatedDependencies = await updateMetadata.parse(commitMessage, 'dependabot/nuget/api/main/coffee-rails', 'main', getAlert, getScore)
+  const updatedDependencies = await updateMetadata.parse(commitMessage, body, 'dependabot/nuget/api/main/coffee-rails', 'main', getAlert, getScore)
 
   expect(updatedDependencies).toHaveLength(2)
 
@@ -103,6 +119,7 @@ test('it supports multiple dependencies within a single fragment', async () => {
   expect(updatedDependencies[0].prevVersion).toEqual('4.0.1')
   expect(updatedDependencies[0].newVersion).toEqual('4.2.2')
   expect(updatedDependencies[0].compatScore).toEqual(34)
+  expect(updatedDependencies[0].maintChange).toEqual(false)
   expect(updatedDependencies[0].alertState).toEqual('DISMISSED')
   expect(updatedDependencies[0].ghsaId).toEqual('GHSA-III-BBB')
   expect(updatedDependencies[0].cvss).toEqual(4.6)
@@ -115,6 +132,7 @@ test('it supports multiple dependencies within a single fragment', async () => {
   expect(updatedDependencies[1].targetBranch).toEqual('main')
   expect(updatedDependencies[1].prevVersion).toEqual('')
   expect(updatedDependencies[1].compatScore).toEqual(0)
+  expect(updatedDependencies[1].maintChange).toEqual(false)
   expect(updatedDependencies[1].alertState).toEqual('')
   expect(updatedDependencies[1].ghsaId).toEqual('')
   expect(updatedDependencies[1].cvss).toEqual(0)
@@ -142,7 +160,7 @@ test('it only returns information within the first fragment if there are multipl
     '\n' +
     'Signed-off-by: dependabot[bot] <support@github.com>'
 
-  const updatedDependencies = await updateMetadata.parse(commitMessage, 'dependabot|nuget|coffee-rails', 'main', undefined, undefined)
+  const updatedDependencies = await updateMetadata.parse(commitMessage, '', 'dependabot|nuget|coffee-rails', 'main', undefined, undefined)
 
   expect(updatedDependencies).toHaveLength(1)
 
@@ -155,6 +173,7 @@ test('it only returns information within the first fragment if there are multipl
   expect(updatedDependencies[0].prevVersion).toEqual('')
   expect(updatedDependencies[0].newVersion).toEqual('')
   expect(updatedDependencies[0].compatScore).toEqual(0)
+  expect(updatedDependencies[0].maintChange).toEqual(false)
   expect(updatedDependencies[0].alertState).toEqual('')
   expect(updatedDependencies[0].ghsaId).toEqual('')
   expect(updatedDependencies[0].cvss).toEqual(0)
@@ -177,7 +196,7 @@ test('it properly handles dependencies which contain slashes', async () => {
 
   const getAlert = async () => Promise.resolve({ alertState: '', ghsaId: '', cvss: 0 })
   const getScore = async () => Promise.resolve(0)
-  const updatedDependencies = await updateMetadata.parse(commitMessage, 'dependabot/nuget/api/rails/coffee', 'main', getAlert, getScore)
+  const updatedDependencies = await updateMetadata.parse(commitMessage, '', 'dependabot/nuget/api/rails/coffee', 'main', getAlert, getScore)
 
   expect(updatedDependencies).toHaveLength(1)
 
@@ -190,6 +209,7 @@ test('it properly handles dependencies which contain slashes', async () => {
   expect(updatedDependencies[0].prevVersion).toEqual('')
   expect(updatedDependencies[0].newVersion).toEqual('')
   expect(updatedDependencies[0].compatScore).toEqual(0)
+  expect(updatedDependencies[0].maintChange).toEqual(false)
   expect(updatedDependencies[0].alertState).toEqual('')
   expect(updatedDependencies[0].ghsaId).toEqual('')
   expect(updatedDependencies[0].cvss).toEqual(0)

--- a/src/dependabot/update_metadata.ts
+++ b/src/dependabot/update_metadata.ts
@@ -15,7 +15,8 @@ export interface updatedDependency extends dependencyAlert {
   targetBranch: string,
   prevVersion: string,
   newVersion: string,
-  compatScore: number
+  compatScore: number,
+  maintChange: boolean
 }
 
 export interface alertLookup {
@@ -26,9 +27,10 @@ export interface scoreLookup {
     (dependencyName: string, previousVersion: string, newVersion: string, ecosystem: string): Promise<number>;
 }
 
-export async function parse (commitMessage: string, branchName: string, mainBranch: string, lookup?: alertLookup, getScore?: scoreLookup): Promise<Array<updatedDependency>> {
+export async function parse (commitMessage: string, body: string, branchName: string, mainBranch: string, lookup?: alertLookup, getScore?: scoreLookup): Promise<Array<updatedDependency>> {
   const bumpFragment = commitMessage.match(/^Bumps .* from (?<from>\d[^ ]*) to (?<to>\d[^ ]*)\.$/m)
   const yamlFragment = commitMessage.match(/^-{3}\n(?<dependencies>[\S|\s]*?)\n^\.{3}\n/m)
+  const newMaintainer = !!body.match(/Maintainer changes/m)
   const lookupFn = lookup ?? (() => Promise.resolve({ alertState: '', ghsaId: '', cvss: 0 }))
   const scoreFn = getScore ?? (() => Promise.resolve(0))
 
@@ -56,6 +58,7 @@ export async function parse (commitMessage: string, branchName: string, mainBran
           prevVersion: lastVersion,
           newVersion: nextVersion,
           compatScore: await scoreFn(dependency['dependency-name'], lastVersion, nextVersion, chunks[1]),
+          maintChange: newMaintainer,
           ...await lookupFn(dependency['dependency-name'], lastVersion, dirname)
         }
       }))

--- a/src/dependabot/util.ts
+++ b/src/dependabot/util.ts
@@ -19,3 +19,8 @@ export function getBranchNames (context: Context): branchNames {
   const { pull_request: pr } = context.payload
   return { headName: pr?.head.ref || '', baseName: pr?.base.ref }
 }
+
+export function getBody (context: Context): string {
+  const { pull_request: pr } = context.payload
+  return pr?.body || ''
+}

--- a/src/dry-run.ts
+++ b/src/dry-run.ts
@@ -53,7 +53,7 @@ async function check (args: any): Promise<void> {
       const branchNames = getBranchNames(newContext)
       const lookupFn = (name, version, directory) => getAlert(name, version, directory, githubClient, actionContext)
 
-      const updatedDependencies = await parse(commitMessage, branchNames.headName, branchNames.baseName, lookupFn, getCompatibility)
+      const updatedDependencies = await parse(commitMessage, pullRequest.body, branchNames.headName, branchNames.baseName, lookupFn, getCompatibility)
 
       if (updatedDependencies.length > 0) {
         console.log('Updated dependencies:')

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -110,6 +110,7 @@ test('it sets the updated dependency as an output for subsequent actions', async
         prevVersion: '4.0.1',
         newVersion: '4.2.2',
         compatScore: 0,
+        maintChange: false,
         alertState: '',
         ghsaId: '',
         cvss: 0
@@ -184,6 +185,7 @@ test('if there are multiple dependencies, it summarizes them', async () => {
         prevVersion: '4.0.1',
         newVersion: '4.2.2',
         compatScore: 34,
+        maintChange: false,
         alertState: '',
         ghsaId: '',
         cvss: 0
@@ -198,6 +200,7 @@ test('if there are multiple dependencies, it summarizes them', async () => {
         prevVersion: '',
         newVersion: '',
         compatScore: 34,
+        maintChange: false,
         alertState: '',
         ghsaId: '',
         cvss: 0

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ export async function run (): Promise<void> {
     // Validate the job
     const commitMessage = await verifiedCommits.getMessage(githubClient, github.context)
     const branchNames = util.getBranchNames(github.context)
+    const body = util.getBody(github.context)
     let alertLookup: updateMetadata.alertLookup | undefined
     if (core.getInput('alert-lookup')) {
       alertLookup = (name, version, directory) => verifiedCommits.getAlert(name, version, directory, githubClient, github.context)
@@ -34,7 +35,7 @@ export async function run (): Promise<void> {
       // Parse metadata
       core.info('Parsing Dependabot metadata')
 
-      const updatedDependencies = await updateMetadata.parse(commitMessage, branchNames.headName, branchNames.baseName, alertLookup, scoreLookup)
+      const updatedDependencies = await updateMetadata.parse(commitMessage, body, branchNames.headName, branchNames.baseName, alertLookup, scoreLookup)
 
       if (updatedDependencies.length > 0) {
         output.set(updatedDependencies)


### PR DESCRIPTION
closes #20 

Ideally this would get passed over in the commit message instead of being part of the (editable) PR body, but that's not part of `fetch-metadata` or `dependabot-core`, so I can't modify that.  So, in the meantime, we can just use the PR body.