### PR TITLE
v1.3.1 Release Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Extract information about the dependencies being updated by a Dependabot-generat
 
 ## Usage instructions
 
-Create a workflow file that contains a step that uses: `dependabot/fetch-metadata@vv1.3.1`, e.g.
+Create a workflow file that contains a step that uses: `dependabot/fetch-metadata@v1.3.1`, e.g.
 
 ```yaml
 -- .github/workflows/dependabot-prs.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Fetch Dependabot metadata
       id: dependabot-metadata
-      uses: dependabot/fetch-metadata@vv1.3.1
+      uses: dependabot/fetch-metadata@v1.3.1
       with:
         alert-lookup: true
         compat-lookup: true
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@vv1.3.1
+        uses: dependabot/fetch-metadata@v1.3.1
       - uses: actions/checkout@v3
       - name: Approve a PR if not already approved
         run: |
@@ -129,7 +129,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@vv1.3.1
+        uses: dependabot/fetch-metadata@v1.3.1
       - name: Enable auto-merge for Dependabot PRs
         if: ${{contains(steps.dependabot-metadata.outputs.dependency-names, 'rails') && steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch'}}
         run: gh pr merge --auto --merge "$PR_URL"
@@ -158,7 +158,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@vv1.3.1
+        uses: dependabot/fetch-metadata@v1.3.1
       - name: Add a label for all production dependencies
         if: ${{ steps.dependabot-metadata.outputs.dependency-type == 'direct:production' }}
         run: gh pr edit "$PR_URL" --add-label "production"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Extract information about the dependencies being updated by a Dependabot-generat
 
 ## Usage instructions
 
-Create a workflow file that contains a step that uses: `dependabot/fetch-metadata@v1.3.0`, e.g.
+Create a workflow file that contains a step that uses: `dependabot/fetch-metadata@vv1.3.1`, e.g.
 
 ```yaml
 -- .github/workflows/dependabot-prs.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Fetch Dependabot metadata
       id: dependabot-metadata
-      uses: dependabot/fetch-metadata@v1.3.0
+      uses: dependabot/fetch-metadata@vv1.3.1
       with:
         alert-lookup: true
         compat-lookup: true
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.3.0
+        uses: dependabot/fetch-metadata@vv1.3.1
       - uses: actions/checkout@v3
       - name: Approve a PR if not already approved
         run: |
@@ -129,7 +129,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.3.0
+        uses: dependabot/fetch-metadata@vv1.3.1
       - name: Enable auto-merge for Dependabot PRs
         if: ${{contains(steps.dependabot-metadata.outputs.dependency-names, 'rails') && steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch'}}
         run: gh pr merge --auto --merge "$PR_URL"
@@ -158,7 +158,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.3.0
+        uses: dependabot/fetch-metadata@vv1.3.1
       - name: Add a label for all production dependencies
         if: ${{ steps.dependabot-metadata.outputs.dependency-type == 'direct:production' }}
         run: gh pr edit "$PR_URL" --add-label "production"

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -22,7 +22,7 @@ fi
 
 new_version=$(npm version "${patch_level}" --no-git-tag-version)
 git checkout -b "${new_version}"-release-notes
-sed -i.bak "s|dependabot/fetch-metadata@v[0-9.]*|dependabot/fetch-metadata@v${new_version}|g" "README.md"
+sed -i.bak "s|dependabot/fetch-metadata@v[0-9.]*|dependabot/fetch-metadata@${new_version}|g" "README.md"
 rm README.md.bak
 git add package.json package-lock.json README.md
 git commit -m "${new_version}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-pull-request-action",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Parse Dependabot commit metadata to automate PR handling",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Highlights

This release is primarily catching up on our dependencies, but it also includes a few bug fixes:

- Correctly populate Dependabot Alert metadata when a manifest is located in the project root, thanks @SalimBensiali 
- Add a workaround for a [dependabot-core bug](https://github.com/dependabot/dependabot-core/issues/4893) that causes the `update-type` to be blank occasionally, thanks @mwaddell 

## What's Changed
* If the `update-type` is missing for some reason, calculate it by @mwaddell in https://github.com/dependabot/fetch-metadata/pull/173
* Updated readme to explain when you need to use a PAT by @mwaddell in https://github.com/dependabot/fetch-metadata/pull/183
* Updated auto approve example to minimizing notifications by @mwaddell in https://github.com/dependabot/fetch-metadata/pull/188
* Bump @types/node from 17.0.19 to 17.0.23 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/191
* Bump @types/jest from 27.4.0 to 27.4.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/168
* Fix incorrect vulnerable manifest path check by @SalimBensiali in https://github.com/dependabot/fetch-metadata/pull/186
* Bump @types/yargs from 17.0.8 to 17.0.10 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/181
* Bump @typescript-eslint/parser from 5.12.1 to 5.17.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/194
* Bump eslint from 8.9.0 to 8.12.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/190
* Bump ts-node from 10.5.0 to 10.7.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/196
* Bump eslint from 8.12.0 to 8.13.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/198
* Bump typescript from 4.5.5 to 4.6.3 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/193
* Bump minimist from 1.2.5 to 1.2.6 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/204
* Bump yargs from 17.3.1 to 17.4.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/199
* Bump @typescript-eslint/parser from 5.17.0 to 5.20.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/202
* Bump @typescript-eslint/eslint-plugin from 5.12.1 to 5.20.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/203
* Dependabot updates run monthly and attempt to auto-compile dist/ by @brrygrdn in https://github.com/dependabot/fetch-metadata/pull/205
* Bump @actions/github from 5.0.0 to 5.0.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/197
* Bump eslint-plugin-import from 2.25.4 to 2.26.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/207
* Bump @types/node from 17.0.23 to 17.0.25 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/208
* Bump @vercel/ncc from 0.33.3 to 0.33.4 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/209
* Bump yaml from 1.10.2 to 2.0.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/206

## New Contributors
* @SalimBensiali made their first contribution in https://github.com/dependabot/fetch-metadata/pull/186

**Full Changelog**: https://github.com/dependabot/fetch-metadata/compare/v1.3.0...v1.3.1