### PR TITLE
Add 'skip-commit-verification' as an input for GitHub Enterprise Server users

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Supported inputs are:
 - `compat-lookup` (boolean)
   - If `true`, then populate the `compatibility-score` output.
   - Defaults to `false`
+- `skip-commit-verification` (boolean)
+  - If `true`, then the action will not expect the commits to have a verification signature. **It is required to set this to 'true' in GitHub Enterprise Server**
+  - Defaults to `false`
 
 Subsequent actions will have access to the following outputs:
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   github-token:
     description: 'The GITHUB_TOKEN secret'
     default: ${{ github.token }}
+  skip-commit-verification:
+    type: boolean
+    description: 'If true, the action will not expect Dependabot commits to be verified. This should be set as 'true' in GHES environments.'
+    default: false
 outputs:
   dependency-names:
     description: 'A comma-separated list of all package names updated.'

--- a/src/dependabot/verified_commits.test.ts
+++ b/src/dependabot/verified_commits.test.ts
@@ -70,6 +70,23 @@ test('it returns false if the commit is has no verification payload', async () =
   expect(await getMessage(mockGitHubClient, mockGitHubPullContext())).toBe(false)
 })
 
+test('it returns the message if the commit is has no verification payload but verification is skipped', async () => {
+  nock('https://api.github.com').get('/repos/dependabot/dependabot/pulls/101/commits')
+    .reply(200, [
+      {
+        author: {
+          login: 'dependabot[bot]'
+        },
+        commit: {
+          message: 'Bump lodash from 1.0.0 to 2.0.0',
+          verification: null
+        }
+      }
+    ])
+
+  expect(await getMessage(mockGitHubClient, mockGitHubPullContext(), true)).toEqual('Bump lodash from 1.0.0 to 2.0.0')
+})
+
 test('it returns false if the commit is not verified', async () => {
   nock('https://api.github.com').get('/repos/dependabot/dependabot/pulls/101/commits')
     .reply(200, [

--- a/src/dependabot/verified_commits.ts
+++ b/src/dependabot/verified_commits.ts
@@ -6,7 +6,7 @@ import https from 'https'
 
 const DEPENDABOT_LOGIN = 'dependabot[bot]'
 
-export async function getMessage (client: InstanceType<typeof GitHub>, context: Context): Promise<string | false> {
+export async function getMessage (client: InstanceType<typeof GitHub>, context: Context, skipCommitVerification = false): Promise<string | false> {
   core.debug('Verifying the job is for an authentic Dependabot Pull Request')
 
   const { pull_request: pr } = context.payload
@@ -43,7 +43,7 @@ export async function getMessage (client: InstanceType<typeof GitHub>, context: 
     return false
   }
 
-  if (!commit.verification?.verified) {
+  if (!skipCommitVerification && !commit.verification?.verified) {
     // TODO: Promote to setFailed
     core.warning(
       "Dependabot's commit signature is not verified, refusing to proceed."

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -10,6 +10,7 @@ beforeEach(() => {
   jest.spyOn(core, 'info').mockImplementation(jest.fn())
   jest.spyOn(core, 'setFailed').mockImplementation(jest.fn())
   jest.spyOn(core, 'startGroup').mockImplementation(jest.fn())
+  jest.spyOn(core, 'getBooleanInput').mockReturnValue(false)
 })
 
 test('it early exits with an error if github-token is not set', async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ export async function run (): Promise<void> {
     const githubClient = github.getOctokit(token)
 
     // Validate the job
-    const commitMessage = await verifiedCommits.getMessage(githubClient, github.context)
+    const commitMessage = await verifiedCommits.getMessage(githubClient, github.context, core.getBooleanInput('skip-commit-verification'))
     const branchNames = util.getBranchNames(github.context)
     let alertLookup: updateMetadata.alertLookup | undefined
     if (core.getInput('alert-lookup')) {


### PR DESCRIPTION
Dependabot is not a verified committer by default in GitHub Enterprise Server, so this action currently cannot be used as it always expects commits to be signed before acting.

In order to support using this action in GHES, let's permit this verification step - and only this verification step - to be skipped via workflow configuration, e.g.

```yaml
-- .github/workflows/dependabot-prs.yml
name: Dependabot Pull Request
on: pull_request_target
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
    - name: Fetch Dependabot metadata
      id: dependabot-metadata
      uses: dependabot/fetch-metadata@v1.3.1
      with:
        alert-lookup: true
        compat-lookup: true
        github-token: "${{ secrets.PAT_TOKEN }}",
        skip-commit-verification: true
```