### PR TITLE
Pin only to major version, not full patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Extract information about the dependencies being updated by a Dependabot-generat
 
 ## Usage instructions
 
-Create a workflow file that contains a step that uses: `dependabot/fetch-metadata@v1.3.3`, e.g.
+Create a workflow file that contains a step that uses: `dependabot/fetch-metadata@v1`, e.g.
 
 ```yaml
 -- .github/workflows/dependabot-prs.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Fetch Dependabot metadata
       id: dependabot-metadata
-      uses: dependabot/fetch-metadata@v1.3.3
+      uses: dependabot/fetch-metadata@v1
       with:
         alert-lookup: true
         compat-lookup: true


### PR DESCRIPTION
I vote that in the Readme we only pin to the major version, not the full patch version.

Two reasons:
1. We don't have to remember to bump the version in the Readme whenever we increment the version. Technically we don't have to do this anyway, but realistically people often copy/paste code snippets so whatever they read is what they'll most likely reuse.
2. If they use the major version, they'll pickup improvements as we release them. This has pros/cons, but I think for this project it's probably the smoother way to go since accidental breakage won't break users prod services, just their CI pipelines. Not hard for them to fix by pinning if that happens.