### PR TITLE
docs: fix auto-merge example

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.PAT_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
 
 ### Labelling


### PR DESCRIPTION
The auto-merge job example produces this error:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

This PR is to fix the README file.