### PR TITLE
Fix broken logo on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-<p align="center">
-  <img src="https://s3.eu-west-2.amazonaws.com/dependabot-images/logo-with-name-horizontal.svg?v5" alt="Dependabot" width="336">
-</p>
+<h1 align="center">
+    <picture>
+        <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg">
+        <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/7659/174594559-0b3ddaa7-e75b-4f10-9dee-b51431a9fd4c.svg">
+        <img src="https://user-images.githubusercontent.com/7659/174594540-5e29e523-396a-465b-9a6e-6cab5b15a568.svg" alt="Dependabot" width="336">
+    </picture>
+</h1>
 
 # Fetch Metadata Action
 


### PR DESCRIPTION
The current logo is broken. So replace with the new one.

Copied from https://github.com/dependabot/dependabot-core/pull/5298.

🎩 💁‍♂️  to @mattt 's attention to detail including supporting both light and dark themes.