### PR TITLE
Don't bump pin versions in `README.md`

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -22,9 +22,7 @@ fi
 
 new_version=$(npm version "${patch_level}" --no-git-tag-version)
 git checkout -b "${new_version}"-release-notes
-sed -i.bak "s|dependabot/fetch-metadata@v[0-9.]*|dependabot/fetch-metadata@${new_version}|g" "README.md"
-rm README.md.bak
-git add package.json package-lock.json README.md
+git add package.json package-lock.json
 git commit -m "${new_version}"
 
 echo "Branch prepared for ${new_version}"


### PR DESCRIPTION
We'd rather suggest folks pin to the floating tag `v1` so they default to automatically updated.

If they'd rather pin deterministically, they should be pinning by SHA, not the full major/min/patch.

Related:
* https://github.com/dependabot/fetch-metadata/pull/246
* https://github.com/dependabot/fetch-metadata/pull/267#discussion_r983986989