### PR TITLE
Drop mention of "locally"

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ jobs:
   - Dependabot PR's:
     - We expect Dependabot PRs to be passing CI and have any changes to the `dist/` folder built for production dependencies
     - Some development dependencies may fail the `dist/` check if they modify the Typescript compilation, these should be updated manually via `npm run build`. See the [`dependabot-build`](https://github.com/dependabot/fetch-metadata/blob/main/.github/workflows/dependabot-build.yml) action for details.
-  - Checkout and update `main` locally, then generate a patch release branch
+  - Checkout and update `main`, then generate a patch release branch
       ```bash
       git checkout main
       git pull


### PR DESCRIPTION
I saw "locally" and thought I had to do this on my laptop and couldn't do this in a codespace for some reason... 

But I tested and turns out a codespace is just fine, so remove mention of "locally"