### PR TITLE
v1.3.5 Release Notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-pull-request-action",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Parse Dependabot commit metadata to automate PR handling",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## What's Changed
* v1.3.4 Release Notes by @Nishnha in https://github.com/dependabot/fetch-metadata/pull/267
* docs: fix auto-merge example by @rribeiro1 in https://github.com/dependabot/fetch-metadata/pull/250
* Bump @types/node from 18.7.18 to 18.11.9 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/275
* Fix object-shorthand linter warnings by @mattt in https://github.com/dependabot/fetch-metadata/pull/276
* Bump @actions/core from 1.9.1 to 1.10.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/272
* Bump @typescript-eslint/eslint-plugin from 5.38.0 to 5.42.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/274
* Bump @actions/github from 5.0.3 to 5.1.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/271
* Bump yargs and @types/yargs by @dependabot in https://github.com/dependabot/fetch-metadata/pull/273
* Document steps for cutting a new release by @jeffwidman in https://github.com/dependabot/fetch-metadata/pull/252
* Don't bump pin versions in `README.md` by @jeffwidman in https://github.com/dependabot/fetch-metadata/pull/280

## New Contributors
* @Nishnha made their first contribution in https://github.com/dependabot/fetch-metadata/pull/267
* @rribeiro1 made their first contribution in https://github.com/dependabot/fetch-metadata/pull/250

**Full Changelog**: https://github.com/dependabot/fetch-metadata/compare/v1...v1.3.5