### PR TITLE
Don't assume `git pull` fetches all branches/tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ jobs:
   - Get the PR reviewed, merge it and publish the release
   - Update the `v1` tracking tag to point to the new version
       ```bash
-      git pull
+      git fetch --all --tags
       git checkout v1.x.x # Check out the release tag
       git tag -f v1 # Force update the tracking tag
       git push -f --tags


### PR DESCRIPTION
While running a release, at this point in the instructions I was on the `v1.3.5-release-notes` branch.

So `git pull` isn't guaranteed to pull updates on `main` etc.

Since we're going to checkout the release tag, a `fetch` is all we need here.