### PR TITLE
v1.3.6 Release Notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-pull-request-action",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Parse Dependabot commit metadata to automate PR handling",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
https://github.com/dependabot/fetch-metadata/releases/tag/untagged-a063b0bb698a41ba3d7a

## What's Changed
* Drop mention of "locally" by @jeffwidman in https://github.com/dependabot/fetch-metadata/pull/281
* Don't assume `git pull` fetches all branches/tags by @jeffwidman in https://github.com/dependabot/fetch-metadata/pull/284
* Clarify release notes slightly by @jeffwidman in https://github.com/dependabot/fetch-metadata/pull/283
* Bump eslint-plugin-promise from 6.0.1 to 6.1.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/287
* Bump @typescript-eslint/parser from 5.38.0 to 5.45.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/290
* Bump yargs and @types/yargs by @dependabot in https://github.com/dependabot/fetch-metadata/pull/286
* Bump @types/node from 18.11.9 to 18.11.10 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/289
* Bump decode-uri-component from 0.2.0 to 0.2.2 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/291
* Bump yaml from 2.1.1 to 2.1.3 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/288
* Bump @types/node from 18.11.10 to 18.11.18 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/296
* Bump @vercel/ncc from 0.34.0 to 0.36.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/294
* Bump dotenv from 16.0.2 to 16.0.3 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/293
* Bump typescript from 4.8.3 to 4.9.4 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/295
* Bump yaml from 2.1.3 to 2.2.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/292
* Bump json5 from 1.0.1 to 1.0.2 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/297
* Bump eslint from 8.23.1 to 8.32.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/303
* Bump @typescript-eslint/parser from 5.45.0 to 5.48.2 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/300
* Bump @typescript-eslint/eslint-plugin from 5.42.0 to 5.48.2 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/302
* Bump eslint-plugin-import from 2.26.0 to 2.27.5 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/301
* Bump nock from 13.2.9 to 13.3.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/299
* Bump @types/yargs from 17.0.15 to 17.0.19 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/304
* Fix parser for libraries by @kachick in https://github.com/dependabot/fetch-metadata/pull/224

## New Contributors
* @kachick made their first contribution in https://github.com/dependabot/fetch-metadata/pull/224

**Full Changelog**: https://github.com/dependabot/fetch-metadata/compare/v1...v1.3.6