### PR TITLE
Add minimum permissions to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ name: Dependabot Pull Request
 on: pull_request_target
 jobs:
   build:
+    permissions:
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
     - name: Fetch Dependabot metadata


### PR DESCRIPTION
This is a change to the docs, only. Does it make sense to add `pull-requests: read` permissions to this README example, now that [restricted permissions is the default](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#:~:text=by%20default%2C%20when%20you%20create%20a%20new%20repository%20in%20your%20personal%20account%2C%20github_token%20only%20has%20read%20access%20for%20the%20contents%20and%20packages%20scopes.%20if%20you%20create%20a%20new%20repository%20in%20an%20organization%2C%20the%20setting%20is%20inherited%20from%20what%20is%20configured%20in%20the%20organization%20settings.) for new personal repositories?

> By default, when you create a new repository in your personal account, GITHUB_TOKEN only has read access for the contents and packages scopes. If you create a new repository in an organization, the setting is inherited from what is configured in the organization settings.

I just added this action to a new repository, following the example in the README, and was surprised by an opaque access error: `Error: Api Error: (403) Resource not accessible by integration`

I think this action requires `pull-requests: read` permissions, at a minimum, to list the commits on a pull request: https://github.com/dependabot/fetch-metadata/blob/e8685ee3f134e48a79d01748722843887276469b/src/dependabot/verified_commits.ts#L32

I confirmed that granting `pull-requests: read` permissions to my workflow was sufficient for the Fetch Metadata action: it resolved the access error.