### PR TITLE
v1.4.0 Release Notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-pull-request-action",
-      "version": "1.3.6",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-pull-request-action",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "description": "Parse Dependabot commit metadata to automate PR handling",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## New Features
* feat: add option to skip internal verifications by @yeikel in https://github.com/dependabot/fetch-metadata/pull/336

## Bugfix
* Allow leading `v` on commit message versions by @jonmcquillan in https://github.com/dependabot/fetch-metadata/pull/338

## Dep Bumps
* Bump @typescript-eslint/eslint-plugin from 5.48.2 to 5.49.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/307
* Bump @types/yargs from 17.0.19 to 17.0.20 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/308
* Bump @typescript-eslint/parser from 5.48.2 to 5.49.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/309
* Bump eslint from 8.32.0 to 8.33.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/315
* Bump @typescript-eslint/parser from 5.49.0 to 5.50.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/314
* Bump @types/yargs from 17.0.20 to 17.0.22 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/312
* Bump @vercel/ncc from 0.36.0 to 0.36.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/311
* Bump typescript from 4.9.4 to 4.9.5 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/313
* Bump yargs from 17.6.2 to 17.7.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/322
* Bump eslint from 8.33.0 to 8.35.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/321
* Bump @typescript-eslint/eslint-plugin from 5.49.0 to 5.54.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/319
* Bump @typescript-eslint/parser from 5.50.0 to 5.54.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/320
* Bump @types/node from 18.11.18 to 18.14.2 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/318
* Bump @types/node from 18.14.2 to 18.15.11 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/324
* Bump eslint from 8.35.0 to 8.37.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/327
* Bump @types/yargs from 17.0.22 to 17.0.24 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/326
* Bump @typescript-eslint/parser from 5.54.0 to 5.57.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/330
* Bump @typescript-eslint/eslint-plugin from 5.54.0 to 5.57.1 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/329
* Bump eslint from 8.37.0 to 8.38.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/340
* Bump @typescript-eslint/parser from 5.57.1 to 5.59.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/341
* Bump @typescript-eslint/eslint-plugin from 5.57.1 to 5.59.0 by @dependabot in https://github.com/dependabot/fetch-metadata/pull/342

## Other
* chore(ee): add devcontainer by @yeikel in https://github.com/dependabot/fetch-metadata/pull/337

## New Contributors
* @jonmcquillan made their first contribution in https://github.com/dependabot/fetch-metadata/pull/338
* @yeikel made their first contribution in https://github.com/dependabot/fetch-metadata/pull/337

**Full Changelog**: https://github.com/dependabot/fetch-metadata/compare/v1...v1.4.0