### PR TITLE
Simplify the release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,24 +187,21 @@ jobs:
   - Dependabot PR's:
     - We expect Dependabot PRs to be passing CI and have any changes to the `dist/` folder built for production dependencies
     - Some development dependencies may fail the `dist/` check if they modify the Typescript compilation, these should be updated manually via `npm run build`. See the [`dependabot-build`](https://github.com/dependabot/fetch-metadata/blob/main/.github/workflows/dependabot-build.yml) action for details.
-  - Checkout and update `main`, then generate a patch release branch
+  - Checkout and update `main`, then use the `bin/bump-version` script to create a release PR
       ```bash
       git checkout main
       git pull
-      bin/bump-version -p patch
+      bin/bump-version -p patch # patch | minor | major
       ```
-  - Generate a draft release for your new version
+  - Merge the PR after getting it reviewed
+  - Create a new release tagged as `v1.X.X` format:
+    - Either via the web UI: https://github.com/dependabot/fetch-metadata/releases/new
+    - Or via the CLI:
       ```bash
       gh release create v1.X.X --generate-notes --draft
       > https://github.com/dependabot/fetch-metadata/releases/tag/untagged-XXXXXX
+      # Use the generated URL to review/edit the release notes, and then publish it.
       ```
-  - Create a PR linking to the release notes for review
-      ```bash
-      gh pr create --title "v1.X.X Release Notes" --body "https://github.com/dependabot/fetch-metadata/releases/tag/untagged-XXXXXX"
-      ```
-  - Copy the release notes from the draft release to the PR description. This is optional, but looks much nicer than a bare URL.
-  - Merge the PR after getting it reviewed
-  - Publish the draft release found at https://github.com/dependabot/fetch-metadata/releases/tag/untagged-XXXXXX
   - Update the `v1` tracking tag to point to the new version
       ```bash
       git fetch --all --tags

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -23,6 +23,9 @@ fi
 new_version=$(npm version "${patch_level}" --no-git-tag-version)
 git checkout -b "${new_version}"-release-notes
 git add package.json package-lock.json
-git commit -m "${new_version}"
 
-echo "Branch prepared for ${new_version}"
+echo "Creating commit / PR linking to the releases notes URL."
+echo "This URL will 404 until the release is actually tagged, which you should do as soon as the PR is merged."
+git commit -m "${new_version}" -m "Release notes: https://github.com/dependabot/fetch-metadata/releases/tag/v${new_version}"
+gh pr create --fill # `fill` re-uses the title / body from the commit
+echo "PR created for ${new_version}"


### PR DESCRIPTION
There's a chicken-and-egg scenario where we don't have the release notes to include in the version bump PR until we create a GitHub release... but we don't want to publish the release until the commit bumping the version actually lands.

The last few times I've cut a `fetch-metadata` release, I've been surprised how I always forget the intricate dance to navigate this chicken-and-egg.

I don't think the juice is worth the squeeze... no one really looks at the changelog notes in the PR, and if in fact having the release notes two different places introduces a risk of drift because both the PR description and the git tag for the release can be edited later on... only the commit history is actually immutable. So if either is edited w/o editing the other, they're out of sync.

The odds of that are low--we rarely edit release notes--but still life is simpler if we merely point the commit/PR description at the URL for the release notes and manage those in a single place.

This also lets us script creating the PR, which is one less thing to do manually.