### PR TITLE
Use the full email for the GitHub Actions bot

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Check in any change to dist/
         run: |
           git add dist/
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          # Specifying the full email allows the avatar to show up: https://github.com/orgs/community/discussions/26560
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "[dependabot skip] Update dist/ with build changes" || exit 0
           git push


### PR DESCRIPTION
This is an aesthetic tweak to let the proper avatar show up:
* https://github.com/orgs/community/discussions/26560
* https://github.com/actions/checkout/pull/1184