### PR TITLE
No need to request escalated permissions for `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,11 +1,10 @@
 name: Dependabot auto-merge
 on: pull_request_target
-permissions:
-  pull-requests: write
-  contents: write
+
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Check out code

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -3,12 +3,10 @@ name: Compile dependabot updates
 on:
   pull_request:
 
-permissions:
-  pull-requests: write
-  contents: write
 jobs:
   fetch-dependabot-metadata:
     runs-on: ubuntu-latest
+
     # We only want to check the metadata on pull_request events from Dependabot itself,
     # any subsequent pushes to the PR should just skip this step so we don't go into
     # a loop on commits created by the `build-dependabot-changes` job
@@ -21,16 +19,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch dependabot metadata
         id: dependabot-metadata
         uses: ./
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   build-dependabot-changes:
     runs-on: ubuntu-latest
     needs: [fetch-dependabot-metadata]
+
     # We only need to build the dist/ folder if the PR relates a production NPM dependency, otherwise we don't expect changes.
     if: needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn' && needs.fetch-dependabot-metadata.outputs.dependency-type == 'direct:production'
     steps:


### PR DESCRIPTION
Several of these job steps that use `GITHUB_TOKEN` are read-only
operations, so they don't need elevated permissions for the
`GITHUB_TOKEN`.

And the jobs that _do_ need elevated permissions we're already using a
PAT, so it's not even using the `GITHUB_TOKEN`.

So no need for any custom permissions on the `GITHUB_TOKEN` at all.