### PR TITLE
Remove unused step

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,10 +10,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Fetch metadata
-        id: metadata
-        uses: ./
-
       - name: Auto-merge
         run: gh pr merge --auto --merge '${{ github.event.pull_request.html_url }}'
         env:


### PR DESCRIPTION
The output of looking for metadata is never used in this workflow, so delete the step.