### PR TITLE
Add workflow for creating release PR's

### DIFF
--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -1,0 +1,83 @@
+name: Release - Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version Type?"
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+        default: "minor"
+
+jobs:
+  Create-PR-To-Bump-Fetch-Metadata-Version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Ensure we start from main in case the workflow is run from a branch
+          ref: "main"
+          token: ${{ secrets.DEPENDABOT_AUTOMATION_PAT }}
+
+      - uses: actions/setup-node@v3 # bin/bump-version needs npm
+        with:
+          node-version-file: .nvmrc
+
+      - name: Bump the version
+        # Currently we don't run via `schedule` trigger since this repo isn't active enough.
+        # However, if that ever changes, it will run with no inputs, so version_type will default to 'minor'
+        run: |
+          NEW_VERSION=$(bin/bump-version ${{ github.event.inputs.version_type || 'minor' }})
+          echo "New version is: $NEW_VERSION"
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Configure the git user
+        run: |
+          git config user.name "github-actions[bot]"
+          # Specifying the full email allows the avatar to show up: https://github.com/orgs/community/discussions/26560
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create a branch and commit the changes
+        run: |
+          # Using an idempotent branch name ensures no duplicate PR's are created
+          # if the action is re-run before the previous PR is merged.
+          # The branch name is purposefully different from the release tag to
+          # avoid ambiguity when selecting git refs.
+          git checkout -b "bump-to-${{ env.NEW_VERSION }}"
+          git add package.json package-lock.json
+          echo "Creating commit / PR linking to the releases notes URL."
+          echo "This URL will 404 until the release is actually tagged, which you should do as soon as the PR is merged."
+          git commit -m "${{ env.NEW_VERSION }}" -m "Release notes: https://github.com/${{ github.repository }}/releases/tag/${{ env.NEW_VERSION }}"
+
+      - name: Push the branch
+        run: |
+          echo "Pushing branch to remote. If this fails, check if a branch/PR already exists for this version."
+          git config push.autoSetupRemote true
+          git push
+
+      - name: Create a PR from the branch with the commit
+        run: |
+          PR_URL=$(gh pr create --fill) # `fill` re-uses the title / body from the commit
+          echo "PR created at URL: $PR_URL"
+          echo "PR_URL=$PR_URL" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMATION_PAT }}
+
+      - name: Set summary
+        run: |
+          echo ":rocket: PR created at URL: ${{ env.PR_URL }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "After the PR is approved/merged, create a new release tagged as \`${{ env.NEW_VERSION }}\`, _making sure to point it at the merge commit_:" >> $GITHUB_STEP_SUMMARY
+          echo "* You can do this via the web UI - use the \`Generate release notes\` button and then edit as needed: https://github.com/${{ github.repository }}/releases/new?tag=${{ env.NEW_VERSION }}&title=${{ env.NEW_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "* Or via the GitHub CLI:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "    gh release create ${{ env.NEW_VERSION }} --title ${{ env.NEW_VERSION }} --generate-notes --draft" >> $GITHUB_STEP_SUMMARY
+          echo "    > https://github.com/${{ github.repository }}/releases/tag/untagged-XXXXXX" >> $GITHUB_STEP_SUMMARY
+          echo "    # Use the generated URL to review/edit the release notes." >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "Once the release is tagged, move the floating \`v1\` tag to point at this release." >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -193,21 +193,13 @@ jobs:
 
  ## Tagging a new release
 
-  1. Checkout and update `main`, then use the `bin/bump-version` script to create a release PR
-      ```bash
-      git checkout main
-      git pull
-      bin/bump-version minor # major | minor | patch
-      ```
-  2. Merge the PR after getting it reviewed
-  3. Create a new release tagged as `v1.X.X` format:
-    - Either via the web UI: https://github.com/dependabot/fetch-metadata/releases/new
-    - Or via the CLI:
-      ```bash
-      gh release create v1.X.X --generate-notes --draft
-      > https://github.com/dependabot/fetch-metadata/releases/tag/untagged-XXXXXX
-      # Use the generated URL to review/edit the release notes, and then publish it.
-      ```
+  Publish a new release by running the [`Release - Bump Version`](https://github.com/dependabot/fetch-metadata/actions/workflows/release-bump-version.yml) workflow and following the instructions on the job summary.
+
+  In a nutshell the process will be:
+
+  1. Run the action to generate a version bump PR.
+  2. Merge the PR.
+  3. Tag that merge commit as a new release using the format `v1.2.3`. The job summary contains a URL pre-populated with the correct version for the title and tag.
   4. Update the `v1` tracking tag to point to the new version
       ```bash
       git fetch --all --tags

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -4,16 +4,8 @@ usage() { echo "Usage: $0 [ major | minor | patch ]" 1>&2; exit 1; }
 
 version_type=$1
 if [ "$version_type" == "major" ] || [ "$version_type" == "minor" ] || [ "$version_type" == "patch" ]; then
-  new_version=$(npm version "$version_type" --no-git-tag-version)
+  new_version=$(npm version "$version_type" --no-git-tag-version) || exit
   echo "$new_version"
-
-  git checkout -b "${new_version}"-release-notes
-  git add package.json package-lock.json
-  echo "Creating commit / PR linking to the releases notes URL."
-  echo "This URL will 404 until the release is actually tagged, which you should do as soon as the PR is merged."
-  git commit -m "${new_version}" -m "Release notes: https://github.com/dependabot/fetch-metadata/releases/tag/v${new_version}"
-  gh pr create --fill # `fill` re-uses the title / body from the commit
-  echo "PR created for ${new_version}"
 else
   usage
 fi


### PR DESCRIPTION
Add a workflow for creating release PR's. This way we don't have to do it locally, and we guarantee the `npm` version used to generate the version bump is consistent and stays in-sync with the repo instead of whatever the dev happened to have on their local computer.