### PR TITLE
Switch to using an app token instead of a PAT

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,10 +7,17 @@ jobs:
 
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@v3
 
       - name: Auto-merge
         run: gh pr merge --auto --merge '${{ github.event.pull_request.html_url }}'
         env:
-          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_AUTOMATION_PAT }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -31,11 +31,18 @@ jobs:
     # We only need to build the dist/ folder if the PR relates a production NPM dependency, otherwise we don't expect changes.
     if: needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn' && needs.fetch-dependabot-metadata.outputs.dependency-type == 'direct:production'
     steps:
-      # Check out using a PAT so any pushed changes will trigger checkruns
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
+
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.DEPENDABOT_AUTOMATION_PAT }}
+          # Check out using an app token so any pushed changes will trigger checkruns
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -18,11 +18,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
+
       - uses: actions/checkout@v3
         with:
           # Ensure we start from main in case the workflow is run from a branch
           ref: "main"
-          token: ${{ secrets.DEPENDABOT_AUTOMATION_PAT }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - uses: actions/setup-node@v3 # bin/bump-version needs npm
         with:
@@ -66,7 +73,7 @@ jobs:
           echo "PR created at URL: $PR_URL"
           echo "PR_URL=$PR_URL" >> $GITHUB_ENV
         env:
-          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMATION_PAT }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Set summary
         run: |

--- a/.github/workflows/release-move-tracking-tag.yml
+++ b/.github/workflows/release-move-tracking-tag.yml
@@ -28,9 +28,16 @@ jobs:
     # the road we increase the robustness of this.
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
+
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.DEPENDABOT_AUTOMATION_PAT }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Move the tracking tag
         run: git tag -f v1


### PR DESCRIPTION
The app token will persist even as users come/go from the :dependabot: team.

It also allows us more finegrained access controls from the app settings page if we need to suddenly lockdown something, we don't have to rely on the person who created the PAT.