### PR TITLE
Simplify `bin/bump-version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ jobs:
       ```bash
       git checkout main
       git pull
-      bin/bump-version -p patch # patch | minor | major
+      bin/bump-version minor # major | minor | patch
       ```
   - Merge the PR after getting it reviewed
   - Create a new release tagged as `v1.X.X` format:

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -1,31 +1,19 @@
 #!/bin/bash
 
-usage() { echo "Usage: $0 -p [major | minor | patch]" 1>&2; exit 1; }
+usage() { echo "Usage: $0 [ major | minor | patch ]" 1>&2; exit 1; }
 
-while getopts "p:" o; do
-  case "${o}" in
-    p)
-      patch_level=${OPTARG}
-      (( patch_level == 'major' || patch_level == 'minor' || patch_level == 'patch'))
-      ;;
-    *)
-      usage
-      ;;
-  esac
-done
+version_type=$1
+if [ "$version_type" == "major" ] || [ "$version_type" == "minor" ] || [ "$version_type" == "patch" ]; then
+  new_version=$(npm version "$version_type" --no-git-tag-version)
+  echo "$new_version"
 
-echo "$patch_level"
-
-if [[ -z "${patch_level}" ]]; then
+  git checkout -b "${new_version}"-release-notes
+  git add package.json package-lock.json
+  echo "Creating commit / PR linking to the releases notes URL."
+  echo "This URL will 404 until the release is actually tagged, which you should do as soon as the PR is merged."
+  git commit -m "${new_version}" -m "Release notes: https://github.com/dependabot/fetch-metadata/releases/tag/v${new_version}"
+  gh pr create --fill # `fill` re-uses the title / body from the commit
+  echo "PR created for ${new_version}"
+else
   usage
 fi
-
-new_version=$(npm version "${patch_level}" --no-git-tag-version)
-git checkout -b "${new_version}"-release-notes
-git add package.json package-lock.json
-
-echo "Creating commit / PR linking to the releases notes URL."
-echo "This URL will 404 until the release is actually tagged, which you should do as soon as the PR is merged."
-git commit -m "${new_version}" -m "Release notes: https://github.com/dependabot/fetch-metadata/releases/tag/v${new_version}"
-gh pr create --fill # `fill` re-uses the title / body from the commit
-echo "PR created for ${new_version}"


### PR DESCRIPTION
Over in
https://github.com/dependabot/fetch-metadata/pull/360#discussion_r1196155497, I noticed that bash was complaining about this script:
```bash
bin/bump-version: line 9: ((: patch_level == 'major' || patch_level == 'minor' || patch_level == 'patch': syntax error: operand expected (error token is "'major' || patch_level == 'minor' || patch_level == 'patch'")
```

I started to dig into it, but the `while` loop isn't needed, the `case` statement felt unecessarily complex so I simplified it to use an `if` statement.

I also changed the argument from a flag-based argument to simple ordered argument, as again it seemed simpler and it matches the style of the bump version script over in `dependabot-core` so it's easier for engineers working across repos. If we later have additional flags, we can always switch it back later.

Lastly, I found `patch_version` confusing given that `patch` is a specific value that can be used, so I renamed it to `version_type`.