### PR TITLE
Stop using deprecated `set-output`

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -16,14 +16,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Read .nvmrc
-        id: nvm
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NVMRC }}
+          node-version-file: .nvmrc
 
       - name: Install NPM dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,10 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Read .nvmrc
-      id: nvm
-      run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ steps.nvm.outputs.NVMRC }}
+        node-version-file: .nvmrc
 
     - name: Install npm dependencies
       run: npm ci

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -37,14 +37,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.DEPENDABOT_AUTOMATION_PAT }}
 
-      - name: Read .nvmrc
-        id: nvm
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
-
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NVMRC }}
+          node-version-file: .nvmrc
 
       - name: Install NPM dependencies
         run: npm ci


### PR DESCRIPTION
The initial impetus for this change was:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

However, it turns out the entire step is unnecesary since `actions/setup-node` supports directly reading the `.nvmrc` file.