### PR TITLE
Group :dependabot: PR's for `eslint`-related deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      eslint-dependencies:
+        patterns:
+          - "*eslint*"


### PR DESCRIPTION
There are multiple deps that are `eslint`-related, and since they're all related to a linter, it's very safe to merge them as a single group.

For example:

1. https://github.com/dependabot/fetch-metadata/pull/373
2. https://github.com/dependabot/fetch-metadata/pull/367
3. https://github.com/dependabot/fetch-metadata/pull/363

So try kicking the tires on the new "grouping" feature that the :dependabot: team is working on.