### PR TITLE
Fixes for alert lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 .idea/
+.vscode/

--- a/dist/index.js
+++ b/dist/index.js
@@ -10282,9 +10282,16 @@ function getAlert(name, version, directory, client, context) {
        }
      }`);
         const nodes = (_b = (_a = alerts === null || alerts === void 0 ? void 0 : alerts.repository) === null || _a === void 0 ? void 0 : _a.vulnerabilityAlerts) === null || _b === void 0 ? void 0 : _b.nodes;
-        const found = nodes === null || nodes === void 0 ? void 0 : nodes.filter((a) => (version === '' || a.vulnerableRequirements === `= ${version}`) &&
-            trimSlashes(a.vulnerableManifestPath) === trimSlashes(`${directory}/${a.vulnerableManifestFilename}`) &&
-            a.securityVulnerability.package.name === name).sort(compare).reverse()[0];
+        const found = nodes
+            .filter((a) => (version === '' ||
+            a.vulnerableRequirements === `= ${version}`) &&
+            [
+                trimSlashes(`${directory}/${a.vulnerableManifestFilename}`),
+                trimSlashes(a.vulnerableManifestFilename)
+            ].includes(trimSlashes(a.vulnerableManifestPath)) &&
+            a.securityVulnerability.package.name === name)
+            .sort(compare)
+            .reverse()[0];
         return {
             alertState: (_c = found === null || found === void 0 ? void 0 : found.state) !== null && _c !== void 0 ? _c : '',
             ghsaId: (_d = found === null || found === void 0 ? void 0 : found.securityAdvisory.ghsaId) !== null && _d !== void 0 ? _d : '',

--- a/dist/index.js
+++ b/dist/index.js
@@ -10209,6 +10209,15 @@ exports.getCompatibility = exports.trimSlashes = exports.getAlert = exports.getM
 const core = __importStar(__nccwpck_require__(2186));
 const https_1 = __importDefault(__nccwpck_require__(5687));
 const DEPENDABOT_LOGIN = 'dependabot[bot]';
+const compare = (a, b) => {
+    if (a.securityAdvisory.cvss.score < b.securityAdvisory.cvss.score) {
+        return -1;
+    }
+    else if (a.securityAdvisory.cvss.score > b.securityAdvisory.cvss.score) {
+        return 1;
+    }
+    return 0;
+};
 function getMessage(client, context, skipCommitVerification = false, skipVerification = false) {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
@@ -10273,9 +10282,9 @@ function getAlert(name, version, directory, client, context) {
        }
      }`);
         const nodes = (_b = (_a = alerts === null || alerts === void 0 ? void 0 : alerts.repository) === null || _a === void 0 ? void 0 : _a.vulnerabilityAlerts) === null || _b === void 0 ? void 0 : _b.nodes;
-        const found = nodes.find(a => (version === '' || a.vulnerableRequirements === `= ${version}`) &&
+        const found = nodes === null || nodes === void 0 ? void 0 : nodes.filter((a) => (version === '' || a.vulnerableRequirements === `= ${version}`) &&
             trimSlashes(a.vulnerableManifestPath) === trimSlashes(`${directory}/${a.vulnerableManifestFilename}`) &&
-            a.securityVulnerability.package.name === name);
+            a.securityVulnerability.package.name === name).sort(compare).reverse()[0];
         return {
             alertState: (_c = found === null || found === void 0 ? void 0 : found.state) !== null && _c !== void 0 ? _c : '',
             ghsaId: (_d = found === null || found === void 0 ? void 0 : found.securityAdvisory.ghsaId) !== null && _d !== void 0 ? _d : '',

--- a/src/dependabot/verified_commits.ts
+++ b/src/dependabot/verified_commits.ts
@@ -106,9 +106,19 @@ export async function getAlert (name: string, version: string, directory: string
      }`)
 
   const nodes = alerts?.repository?.vulnerabilityAlerts?.nodes
-  const found = nodes?.filter((a: any) => (version === '' || a.vulnerableRequirements === `= ${version}`) &&
-      trimSlashes(a.vulnerableManifestPath) === trimSlashes(`${directory}/${a.vulnerableManifestFilename}`) &&
-      a.securityVulnerability.package.name === name)
+  const found = nodes
+    .filter(
+      (a: any) =>
+        (
+          version === '' ||
+          a.vulnerableRequirements === `= ${version}`
+        ) &&
+        [
+          trimSlashes(`${directory}/${a.vulnerableManifestFilename}`),
+          trimSlashes(a.vulnerableManifestFilename)
+        ].includes(trimSlashes(a.vulnerableManifestPath)) &&
+        a.securityVulnerability.package.name === name
+    )
     .sort(compare)
     .reverse()[0]
 


### PR DESCRIPTION
This addresses a few issues on the alert-lookup functionality.

1. The system currently shows the first matching alert it finds, yet some PRs address multiple alerts. This code change sorts the matching alerts by their security score first and returns the highest alert.
2. The system currently requires a matching path, yet some PRs do not have a path. This code change covers situations where vulnerableManifestPath does not include a directory.

Example for 2️⃣ :
```
Dependency Names = nth-check, @svgr/webpack
Directory = "/nth-check-and-svgr"
Package Ecosystem = npm_and_yarn
vulnerableManifestFilename = "package-lock.json"
vulnerableManifestPath = "package-lock.json"
ghsa-id = GHSA-rp65-9cf3-cjxr
cvss = 7.5
 ```