### PR TITLE
Adds multiple path matching

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10273,9 +10273,14 @@ function getAlert(name, version, directory, client, context) {
        }
      }`);
         const nodes = (_b = (_a = alerts === null || alerts === void 0 ? void 0 : alerts.repository) === null || _a === void 0 ? void 0 : _a.vulnerabilityAlerts) === null || _b === void 0 ? void 0 : _b.nodes;
-        const found = nodes.find(a => (version === '' || a.vulnerableRequirements === `= ${version}`) &&
-            trimSlashes(a.vulnerableManifestPath) === trimSlashes(`${directory}/${a.vulnerableManifestFilename}`) &&
-            a.securityVulnerability.package.name === name);
+        const found = nodes
+            .filter((a) => (version === '' ||
+            a.vulnerableRequirements === `= ${version}`) &&
+            [
+                trimSlashes(`${directory}/${a.vulnerableManifestFilename}`),
+                trimSlashes(a.vulnerableManifestFilename)
+            ].includes(trimSlashes(a.vulnerableManifestPath)) &&
+            a.securityVulnerability.package.name === name)[0];
         return {
             alertState: (_c = found === null || found === void 0 ? void 0 : found.state) !== null && _c !== void 0 ? _c : '',
             ghsaId: (_d = found === null || found === void 0 ? void 0 : found.securityAdvisory.ghsaId) !== null && _d !== void 0 ? _d : '',

--- a/src/dependabot/verified_commits.test.ts
+++ b/src/dependabot/verified_commits.test.ts
@@ -229,12 +229,14 @@ test('it returns default if it does not match the directory', async () => {
   nock('https://api.github.com').post('/graphql', query)
     .reply(200, response)
 
-  expect(await getAlert('coffee-script', '4.0.1', '/', mockGitHubClient, mockGitHubPullContext())).toEqual({ alertState: '', cvss: 0, ghsaId: '' })
+  expect(await getAlert('coffee-script', '4.0.1', '/differentPath', mockGitHubClient, mockGitHubPullContext())).toEqual({ alertState: '', cvss: 0, ghsaId: '' })
+})
 
+test('it returns values if the manifest file is at root', async () => {
   nock('https://api.github.com').post('/graphql', query)
     .reply(200, responseWithManifestFileAtRoot)
 
-  expect(await getAlert('coffee-script', '4.0.1', '/wwwroot', mockGitHubClient, mockGitHubPullContext())).toEqual({ alertState: '', cvss: 0, ghsaId: '' })
+  expect(await getAlert('coffee-script', '4.0.1', '/', mockGitHubClient, mockGitHubPullContext())).toEqual({ alertState: 'DISMISSED', cvss: 4.5, ghsaId: 'FOO' })
 })
 
 test('it returns default if it does not match the name', async () => {
@@ -301,7 +303,7 @@ test('getCompatibility handles errors', async () => {
 
 const mockGitHubClient = github.getOctokit('mock-token')
 
-function mockGitHubOtherContext (): Context {
+function mockGitHubOtherContext(): Context {
   const ctx = new Context()
   ctx.payload = {
     issue: {
@@ -311,7 +313,7 @@ function mockGitHubOtherContext (): Context {
   return ctx
 }
 
-function mockGitHubPullContext (author = 'dependabot[bot]'): Context {
+function mockGitHubPullContext(author = 'dependabot[bot]'): Context {
   const ctx = new Context()
   ctx.payload = {
     pull_request: {

--- a/src/dependabot/verified_commits.test.ts
+++ b/src/dependabot/verified_commits.test.ts
@@ -303,7 +303,7 @@ test('getCompatibility handles errors', async () => {
 
 const mockGitHubClient = github.getOctokit('mock-token')
 
-function mockGitHubOtherContext(): Context {
+function mockGitHubOtherContext (): Context {
   const ctx = new Context()
   ctx.payload = {
     issue: {
@@ -313,7 +313,7 @@ function mockGitHubOtherContext(): Context {
   return ctx
 }
 
-function mockGitHubPullContext(author = 'dependabot[bot]'): Context {
+function mockGitHubPullContext (author = 'dependabot[bot]'): Context {
   const ctx = new Context()
   ctx.payload = {
     pull_request: {

--- a/src/dependabot/verified_commits.ts
+++ b/src/dependabot/verified_commits.ts
@@ -79,9 +79,19 @@ export async function getAlert (name: string, version: string, directory: string
      }`)
 
   const nodes = alerts?.repository?.vulnerabilityAlerts?.nodes
-  const found = nodes.find(a => (version === '' || a.vulnerableRequirements === `= ${version}`) &&
-      trimSlashes(a.vulnerableManifestPath) === trimSlashes(`${directory}/${a.vulnerableManifestFilename}`) &&
-      a.securityVulnerability.package.name === name)
+  const found = nodes
+    .filter(
+      (a: any) =>
+        (
+          version === '' ||
+          a.vulnerableRequirements === `= ${version}`
+        ) &&
+        [
+          trimSlashes(`${directory}/${a.vulnerableManifestFilename}`),
+          trimSlashes(a.vulnerableManifestFilename)
+        ].includes(trimSlashes(a.vulnerableManifestPath)) &&
+        a.securityVulnerability.package.name === name
+    )[0]
 
   return {
     alertState: found?.state ?? '',


### PR DESCRIPTION
Covers situations where vulnerableManifestPath does not include a directory.

Example:
Dependency Names = nth-check, @svgr/webpack
Directory = "/nth-check-and-svgr"
Package Ecosystem = npm_and_yarn
vulnerableManifestFilename = "package-lock.json"
vulnerableManifestPath = "package-lock.json"
ghsa-id = GHSA-rp65-9cf3-cjxr
cvss = 7.5