### PR TITLE
Aggressively group prod and dev dependencies for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,18 @@ updates:
       day: "sunday"
       time: "16:00"
     groups:
-      eslint-dependencies:
+      dependencies:
+        patterns:
+          - "*actions*"
+          - "*pluralize*"
+      dev-dependencies:
         patterns:
           - "*eslint*"
+          - "*types*"
+          - "*vercel"
+          - "*dotenv*"
+          - "*jest*"
+          - "*nock*"
+          - "*node*"
+          - "*yaml*"
+          - "*yargs*"


### PR DESCRIPTION
Use wildcard matching to aggregate prod and dev updates into two separate groups