### PR TITLE
Change actions/checkout@v3 to v4 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ jobs:
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v1
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Approve a PR if not already approved
         run: |
           gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`


### PR DESCRIPTION
Update our reference of `actions/checkout@v3` in the readme to `actions/checkout@v4`