### PR TITLE
Improve directory name extraction from branch name.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10107,13 +10107,14 @@ function parse(commitMessage, body, branchName, mainBranch, lookup, getScore) {
             const prev = (_b = (_a = bumpFragment === null || bumpFragment === void 0 ? void 0 : bumpFragment.groups) === null || _a === void 0 ? void 0 : _a.from) !== null && _b !== void 0 ? _b : ((_d = (_c = updateFragment === null || updateFragment === void 0 ? void 0 : updateFragment.groups) === null || _c === void 0 ? void 0 : _c.from) !== null && _d !== void 0 ? _d : '');
             const next = (_f = (_e = bumpFragment === null || bumpFragment === void 0 ? void 0 : bumpFragment.groups) === null || _e === void 0 ? void 0 : _e.to) !== null && _f !== void 0 ? _f : ((_h = (_g = updateFragment === null || updateFragment === void 0 ? void 0 : updateFragment.groups) === null || _g === void 0 ? void 0 : _g.to) !== null && _h !== void 0 ? _h : '');
             const dependencyGroup = (_k = (_j = groupName === null || groupName === void 0 ? void 0 : groupName.groups) === null || _j === void 0 ? void 0 : _j.name) !== null && _k !== void 0 ? _k : '';
+            const delimIsDash = delim === '-';
             if (data['updated-dependencies']) {
                 return yield Promise.all(data['updated-dependencies'].map((dependency, index) => __awaiter(this, void 0, void 0, function* () {
-                    const dirname = `/${chunks.slice(2, -1 * (1 + (dependency['dependency-name'].match(/\//g) || []).length)).join(delim) || ''}`;
+                    const dirname = `/${chunks.slice(2, -1 * (delimIsDash ? 2 : 1 + (dependency['dependency-name'].match(/\//g) || []).length)).join('/') || ''}`;
                     const lastVersion = index === 0 ? prev : '';
                     const nextVersion = index === 0 ? next : '';
                     const updateType = dependency['update-type'] || calculateUpdateType(lastVersion, nextVersion);
-                    return Object.assign({ dependencyName: dependency['dependency-name'], dependencyType: dependency['dependency-type'], updateType, directory: dirname, packageEcosystem: chunks[1], targetBranch: mainBranch, prevVersion: lastVersion, newVersion: nextVersion, compatScore: yield scoreFn(dependency['dependency-name'], lastVersion, nextVersion, chunks[1]), maintainerChanges: newMaintainer, dependencyGroup: dependencyGroup }, yield lookupFn(dependency['dependency-name'], lastVersion, dirname));
+                    return Object.assign({ dependencyName: dependency['dependency-name'], dependencyType: dependency['dependency-type'], updateType, directory: dirname, packageEcosystem: chunks[1], targetBranch: mainBranch, prevVersion: lastVersion, newVersion: nextVersion, compatScore: yield scoreFn(dependency['dependency-name'], lastVersion, nextVersion, chunks[1]), maintainerChanges: newMaintainer, dependencyGroup }, yield lookupFn(dependency['dependency-name'], lastVersion, dirname));
                 })));
             }
         }

--- a/src/dependabot/update_metadata.test.ts
+++ b/src/dependabot/update_metadata.test.ts
@@ -314,3 +314,79 @@ test('calculateUpdateType should handle all paths', () => {
   expect(updateMetadata.calculateUpdateType('1.1.1', '1.1.2')).toEqual('version-update:semver-patch')
   expect(updateMetadata.calculateUpdateType('1.1.1.1', '1.1.1.2')).toEqual('version-update:semver-patch')
 })
+
+test("handles - as separator", async () => {
+  const commitMessage =
+    'Bumps [stripe](https://github.com/stripe/stripe-python) from 3.5.0 to 8.1.0.\n' +
+    '- [Release notes](https://github.com/stripe/stripe-python/releases)\n' +
+    '- [Changelog](https://github.com/stripe/stripe-python/blob/master/CHANGELOG.md)\n' +
+    '- [Commits](stripe/stripe-python@v3.5.0...v8.1.0)\n' +
+    '\n' +
+    '---\n' +
+    'updated-dependencies:\n' +
+    '- dependency-name: stripe\n' +
+    '  dependency-type: direct:production\n' +
+    '  update-type: version-update:semver-major\n' +
+    '...\n' +
+    '\n' +
+    'Signed-off-by: dependabot[bot] <support@github.com>\n'
+
+  const getAlert = async () => Promise.resolve({ alertState: '', ghsaId: '', cvss: 0 })
+  const getScore = async () => Promise.resolve(0)
+  const updatedDependencies = await updateMetadata.parse(commitMessage, '', 'dependabot-pip-dirname-stripe-8.1.0', 'main', getAlert, getScore)
+
+  expect(updatedDependencies).toHaveLength(1)
+
+  expect(updatedDependencies[0].dependencyName).toEqual('stripe')
+  expect(updatedDependencies[0].dependencyType).toEqual('direct:production')
+  expect(updatedDependencies[0].updateType).toEqual('version-update:semver-major')
+  expect(updatedDependencies[0].directory).toEqual('/dirname')
+  expect(updatedDependencies[0].packageEcosystem).toEqual('pip')
+  expect(updatedDependencies[0].targetBranch).toEqual('main')
+  expect(updatedDependencies[0].prevVersion).toEqual('3.5.0')
+  expect(updatedDependencies[0].newVersion).toEqual('8.1.0')
+  expect(updatedDependencies[0].compatScore).toEqual(0)
+  expect(updatedDependencies[0].maintainerChanges).toEqual(false)
+  expect(updatedDependencies[0].alertState).toEqual('')
+  expect(updatedDependencies[0].ghsaId).toEqual('')
+  expect(updatedDependencies[0].cvss).toEqual(0)
+  expect(updatedDependencies[0].dependencyGroup).toEqual('')
+});
+
+test("it handles multi-segment directory with non-standard separator", async () => {
+  const commitMessage =
+    'Bumps [stripe](https://github.com/stripe/stripe-python) from 3.5.0 to 8.1.0.\n' +
+    '- [Release notes](https://github.com/stripe/stripe-python/releases)\n' +
+    '- [Changelog](https://github.com/stripe/stripe-python/blob/master/CHANGELOG.md)\n' +
+    '- [Commits](stripe/stripe-python@v3.5.0...v8.1.0)\n' +
+    '\n' +
+    '---\n' +
+    'updated-dependencies:\n' +
+    '- dependency-name: stripe\n' +
+    '  dependency-type: direct:production\n' +
+    '  update-type: version-update:semver-major\n' +
+    '...\n' +
+    '\n' +
+    'Signed-off-by: dependabot[bot] <support@github.com>\n'
+
+  const getAlert = async () => Promise.resolve({ alertState: '', ghsaId: '', cvss: 0 })
+  const getScore = async () => Promise.resolve(0)
+  const updatedDependencies = await updateMetadata.parse(commitMessage, '', 'dependabot|pip|dirname|dirname|stripe-8.1.0', 'main', getAlert, getScore)
+
+  expect(updatedDependencies).toHaveLength(1)
+
+  expect(updatedDependencies[0].dependencyName).toEqual('stripe')
+  expect(updatedDependencies[0].dependencyType).toEqual('direct:production')
+  expect(updatedDependencies[0].updateType).toEqual('version-update:semver-major')
+  expect(updatedDependencies[0].directory).toEqual('/dirname/dirname')
+  expect(updatedDependencies[0].packageEcosystem).toEqual('pip')
+  expect(updatedDependencies[0].targetBranch).toEqual('main')
+  expect(updatedDependencies[0].prevVersion).toEqual('3.5.0')
+  expect(updatedDependencies[0].newVersion).toEqual('8.1.0')
+  expect(updatedDependencies[0].compatScore).toEqual(0)
+  expect(updatedDependencies[0].maintainerChanges).toEqual(false)
+  expect(updatedDependencies[0].alertState).toEqual('')
+  expect(updatedDependencies[0].ghsaId).toEqual('')
+  expect(updatedDependencies[0].cvss).toEqual(0)
+  expect(updatedDependencies[0].dependencyGroup).toEqual('')
+});

--- a/src/dependabot/update_metadata.test.ts
+++ b/src/dependabot/update_metadata.test.ts
@@ -315,7 +315,7 @@ test('calculateUpdateType should handle all paths', () => {
   expect(updateMetadata.calculateUpdateType('1.1.1.1', '1.1.1.2')).toEqual('version-update:semver-patch')
 })
 
-test("handles - as separator", async () => {
+test('handles - as separator', async () => {
   const commitMessage =
     'Bumps [stripe](https://github.com/stripe/stripe-python) from 3.5.0 to 8.1.0.\n' +
     '- [Release notes](https://github.com/stripe/stripe-python/releases)\n' +
@@ -351,9 +351,9 @@ test("handles - as separator", async () => {
   expect(updatedDependencies[0].ghsaId).toEqual('')
   expect(updatedDependencies[0].cvss).toEqual(0)
   expect(updatedDependencies[0].dependencyGroup).toEqual('')
-});
+})
 
-test("it handles multi-segment directory with non-standard separator", async () => {
+test('it handles multi-segment directory with non-standard separator', async () => {
   const commitMessage =
     'Bumps [stripe](https://github.com/stripe/stripe-python) from 3.5.0 to 8.1.0.\n' +
     '- [Release notes](https://github.com/stripe/stripe-python/releases)\n' +
@@ -389,4 +389,4 @@ test("it handles multi-segment directory with non-standard separator", async () 
   expect(updatedDependencies[0].ghsaId).toEqual('')
   expect(updatedDependencies[0].cvss).toEqual(0)
   expect(updatedDependencies[0].dependencyGroup).toEqual('')
-});
+})

--- a/src/dependabot/update_metadata.ts
+++ b/src/dependabot/update_metadata.ts
@@ -65,7 +65,7 @@ export async function parse (commitMessage: string, body: string, branchName: st
           newVersion: nextVersion,
           compatScore: await scoreFn(dependency['dependency-name'], lastVersion, nextVersion, chunks[1]),
           maintainerChanges: newMaintainer,
-          dependencyGroup: dependencyGroup,
+          dependencyGroup,
           ...await lookupFn(dependency['dependency-name'], lastVersion, dirname)
         }
       }))

--- a/src/dependabot/update_metadata.ts
+++ b/src/dependabot/update_metadata.ts
@@ -46,10 +46,11 @@ export async function parse (commitMessage: string, body: string, branchName: st
     const prev = bumpFragment?.groups?.from ?? (updateFragment?.groups?.from ?? '')
     const next = bumpFragment?.groups?.to ?? (updateFragment?.groups?.to ?? '')
     const dependencyGroup = groupName?.groups?.name ?? ''
+    const delimIsDash = delim === '-'
 
     if (data['updated-dependencies']) {
       return await Promise.all(data['updated-dependencies'].map(async (dependency, index) => {
-        const dirname = `/${chunks.slice(2, -1 * (1 + (dependency['dependency-name'].match(/\//g) || []).length)).join(delim) || ''}`
+        const dirname = `/${chunks.slice(2, -1 * (delimIsDash ? 2 : 1 + (dependency['dependency-name'].match(/\//g) || []).length)).join('/') || ''}`
         const lastVersion = index === 0 ? prev : ''
         const nextVersion = index === 0 ? next : ''
         const updateType = dependency['update-type'] || calculateUpdateType(lastVersion, nextVersion)


### PR DESCRIPTION
Fixes #493 
Fixes #494 

This improves directory extraction to handle two previously unhandled cases:

1. a multi-segment directory with a non-standard separator is now properly reconstructed by joining on `/`
2. the `-` included in the `depname-version` portion is properly accounted for when the delimiter is `-`.

I did not address the fact that the existing non-standard separator test uses a separator (`|`) that does not appear to be valid according to [the dependabot documention](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#pull-request-branch-nameseparator).