### PR TITLE
Scope app token to only this repo for security

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
           private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
+          repositories: "dependabot/fetch-metadata"
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
           private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
+          repositories: "dependabot/fetch-metadata"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
           private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
+          repositories: "dependabot/fetch-metadata"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-move-tracking-tag.yml
+++ b/.github/workflows/release-move-tracking-tag.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
           private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
+          repositories: "dependabot/fetch-metadata"
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
https://github.com/dependabot/fetch-metadata/pull/442 bumped to a new version of this action which now supports a `"repositories"` key that scopes the token to the designated repositories.