### PR TITLE
Revert "Scope app token to only this repo for security"

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,6 @@ jobs:
         with:
           app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
           private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
-          repositories: "dependabot/fetch-metadata"
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
           private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
-          repositories: "dependabot/fetch-metadata"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
           private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
-          repositories: "dependabot/fetch-metadata"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-move-tracking-tag.yml
+++ b/.github/workflows/release-move-tracking-tag.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
           private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
-          repositories: "dependabot/fetch-metadata"
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Reverts dependabot/fetch-metadata#501

When I tried to cut a release, this was generating a [JSON parsing error](https://github.com/dependabot/fetch-metadata/actions/runs/8369699804/job/22915871426#step:2:1):
```
SyntaxError: Unexpected token 'd', "dependabot"... is not valid JSON
    at JSON.parse (<anonymous>)
    at parseOptions (file:///home/runner/work/_actions/tibdex/github-app-token/3beb63f4bd073e61482598c45c71c1019b59b73a/dist/main/index.js:9:88540)
    at file:///home/runner/work/_actions/tibdex/github-app-token/3beb63f4bd073e6[14](https://github.com/dependabot/fetch-metadata/actions/runs/8369699804/job/22915871426#step:2:15)82598c45c71c1019b59b73a/dist/main/index.js:9:87507
    at run (file:///home/runner/work/_actions/tibdex/github-app-token/3beb63f4bd073e61482598c45c71c1019b59b73a/dist/main/index.js:9:88817)
    at file:///home/runner/work/_actions/tibdex/github-app-token/3beb63f4bd073e61482598c45c71c1019b59b73a/dist/main/index.js:9:87480
    at __nccwpck_require__.a (file:///home/runner/work/_actions/tibdex/github-app-token/3beb63f4bd073e61482598c45c71c1019b59b73a/dist/main/index.js:9:368729)
    at 399 (file:///home/runner/work/_actions/tibdex/github-app-token/3beb63f4bd073e61482598c45c71c1019b59b73a/dist/main/index.js:9:87363)
    at __nccwpck_require__ (file:///home/runner/work/_actions/tibdex/github-app-token/3beb63f4bd073e61482598c45c71c1019b59b73a/dist/main/index.js:9:367817)
    at file:///home/runner/work/_actions/tibdex/github-app-token/3beb63f4bd073e61482598c45c71c1019b59b73a/dist/main/index.js:9:3696[15](https://github.com/dependabot/fetch-metadata/actions/runs/8369699804/job/22915871426#step:2:16)
    at ModuleJob.run (node:internal/modules/esm/module_job:2[17](https://github.com/dependabot/fetch-metadata/actions/runs/8369699804/job/22915871426#step:2:18):25)
``` 

It's probably something stupid simple that I overlooked, but I happened to see there's now an official GitHub action that [we should probably be using instead](https://github.com/tibdex/github-app-token/issues/99#issuecomment-1787602874) as explained by @gr2m for security reasons.

So let's revert this to get releases working, and then I'll file a ticket to track migrating to the new action as a separate follow-on item. We'll need to do this migration in https://github.com/dependabot/dependabot-core/ as well.