### PR TITLE
Switch to the official action for managing app tokens

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,11 +9,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
         with:
-          app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
-          private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
-          repositories: "dependabot/fetch-metadata"
+          app-id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -33,11 +33,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
         with:
-          app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
-          private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
-          repositories: "dependabot/fetch-metadata"
+          app-id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -20,11 +20,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
         with:
-          app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
-          private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
-          repositories: "dependabot/fetch-metadata"
+          app-id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-move-tracking-tag.yml
+++ b/.github/workflows/release-move-tracking-tag.yml
@@ -30,11 +30,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
         with:
-          app_id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
-          private_key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
-          repositories: "dependabot/fetch-metadata"
+          app-id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Improve security by switching to the official GitHub action for managing app tokens. More [details](https://github.com/tibdex/github-app-token/issues/99#issuecomment-1787602874).

The `repositories` key is safe to remove because per the [docs](https://github.com/actions/create-github-app-token?tab=readme-ov-file#repositories):

> If owner and repositories are empty, access will be scoped to only the current repository.

See also:
* https://github.com/dependabot/dependabot-core/pull/9340