### PR TITLE
Relax `engine-strict=true`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true


### PR DESCRIPTION
Looking at git history, this was added in https://github.com/dependabot/fetch-metadata/pull/251 and was probably an overzealous add TBH.

I often like pinning, but here it's breaking our :dependabot: runs: 
* https://github.com/dependabot/fetch-metadata/issues/507

So let's relax it for now. If we later run into problems, we can always tighten the screws later.

Fix:
* #507 