### PR TITLE
Fixed missing outputs in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,8 @@ outputs:
     description: 'If this PR has a known compatibility score and `compat-lookup` is `true`, this contains the compatibility score (otherwise it contains 0).'
   maintainer-changes:
     description: 'Whether or not the the body of this PR contains the phrase "Maintainer changes" which is an indicator of whether or not any maintainers have changed.'
+  dependency-group:
+    description: 'The dependency group that the PR is associated with (otherwise it is an empty string).'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
VS Code doesn't recognize a possible output named `dependency-group` because it's not declared in `action.yml`. 

<img width="805" alt="Screenshot 2024-10-23 at 12 40 46 PM" src="https://github.com/user-attachments/assets/31b46f0b-94a4-489a-84f6-b56e141beb31">

This new output was added back in https://github.com/dependabot/fetch-metadata/pull/396 but it didn't update `action.yml` at the time. This PR resolves the issue by copying the `dependency-group` information from `README` to `action.yml`.