### PR TITLE
Stop using a node16 devcontainer image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,0 @@
-{
-  "name": "Node.js",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:0-16",
-  "postCreateCommand": "npm install"
-}


### PR DESCRIPTION
This was originally added because actions was still on node 16, but codespaces / devcontainers were running newer:
* https://github.com/dependabot/fetch-metadata/issues/334
* https://github.com/dependabot/fetch-metadata/pull/337

However, Actions has now migrated to node 20:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

And we migrated this action here:
* https://github.com/dependabot/fetch-metadata/pull/443

So now we have the opposite problem, that our devcontainer is now outdated.

I considered updating it, but we'd prefer not to manage these versions unless we have to... as it's just one more thing to maintain on a repo that doesn't see a lot of activity.

So instead I removed it and we'll just inherit the default for now. If we later need a custom one, it's easy to re-add.