### PR TITLE
Remove unnecessary hardcoding of `ref`

### DIFF
--- a/.github/workflows/check-uncommitted.yml
+++ b/.github/workflows/check-uncommitted.yml
@@ -14,8 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -36,8 +34,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Compare the expected vs actual files
         run: test -z "$(git status --porcelain)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,8 +14,7 @@ jobs:
           app-id: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.FETCH_METADATA_ACTION_AUTOMATION_PRIVATE_KEY }}
 
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Auto-merge
         run: gh pr merge --auto --merge '${{ github.event.pull_request.html_url }}'

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -17,8 +17,6 @@ jobs:
       package-ecosystem: ${{ steps.dependabot-metadata.outputs.package-ecosystem }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Fetch dependabot metadata
         id: dependabot-metadata
@@ -40,7 +38,6 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
           # Check out using an app token so any pushed changes will trigger checkruns
           token: ${{ steps.generate_token.outputs.token }}
 


### PR DESCRIPTION
I'm copying the setup of one of these actions to another repo, and the hardcoding of `ref` surprised me... these should be the same as the defaault behavior. I checked with Barry who originally committed these files, and he didn't remember why... possibly he'd hardcoded them when testing the action and forgot to remove them.

So let's pull them out to remove confusion.