### PR TITLE
Enable caching of `npm install`/`npm ci` for `setup-node` action

### DIFF
--- a/.github/workflows/check-uncommitted.yml
+++ b/.github/workflows/check-uncommitted.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: 'npm'
 
       - name: Install NPM dependencies
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
+    - uses: actions/setup-node@v4
       with:
         node-version-file: .nvmrc
+        cache: 'npm'
 
-    - name: Install npm dependencies
-      run: npm ci
+    - run: npm ci
 
-    - name: Run linter
-      run: npm run lint
+    - run: npm run lint
 
-    - name: Run tests
-      run: npm test
+    - run: npm test

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -41,13 +41,12 @@ jobs:
           # Check out using an app token so any pushed changes will trigger checkruns
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+          cache: 'npm'
 
-      - name: Install NPM dependencies
-        run: npm ci
+      - run: npm ci
 
       - name: Rebuild the dist/ directory
         run: npm run build

--- a/.github/workflows/release-bump-version.yml
+++ b/.github/workflows/release-bump-version.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/setup-node@v4 # bin/bump-version needs npm
         with:
           node-version-file: .nvmrc
+          cache: 'npm'
 
       - name: Bump the version
         # Cron runs with no inputs, so version_type will default to 'minor'


### PR DESCRIPTION
The `setup-node` action now supports caching the results of `npm install`/`npm ci`:
https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/