### PR TITLE
doc: Write doc for `compat-lookup`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Supported inputs are:
 - `github-token` (string)
   - The `GITHUB_TOKEN` secret
   - Defaults to `${{ github.token }}`
-  - Note: this must be set to a [personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) or an [installation access token (App Token)](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) if you enable `alert-lookup` or `compat-lookup`.
+  - Note: this must be set to a [personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) or an [installation access token (App Token)](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) if you enable `alert-lookup`.
 - `alert-lookup` (boolean)
   - If `true`, then populate the `alert-state`, `ghsa-id` and `cvss` outputs.
   - Defaults to `false`
@@ -49,7 +49,7 @@ Supported inputs are:
 - `compat-lookup` (boolean)
   - If `true`, then populate the `compatibility-score` output.
   - Defaults to `false`
-  - Note: the `github-token` field must be set to a [personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+  - Note: To use this field, `contents: read` and `pull-requests: read` permissions are required for `secrets.GITHUB_TOKEN`. For more details, see [this](#compatibility-score)
 - `skip-commit-verification` (boolean)
   - If `true`, then the action will not expect the commits to have a verification signature. **It is required to set this to 'true' in GitHub Enterprise Server**
   - Defaults to `false`
@@ -218,6 +218,41 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           alert-lookup: true
+```
+
+### Compatibility score
+This is a simple example of how to use `compat-lookup`.
+
+```yml
+name: dependabot-compatibility-score
+
+on:
+  pull_request:
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+
+    if: github.actor == 'dependabot[bot]'
+
+    # Following is required for compat-lookup
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          compat-lookup: true
+
+      - name: Print compatibility-score
+        run: echo "COMPATIBILITY_SCORE=${COMPATIBILITY_SCORE}"
+        env:
+          COMPATIBILITY_SCORE: ${{ steps.metadata.outputs.compatibility-score }}
 ```
 
 ## Notes for project maintainers:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Supported inputs are:
 - `compat-lookup` (boolean)
   - If `true`, then populate the `compatibility-score` output.
   - Defaults to `false`
-  - Note: To use this field, `contents: read` and `pull-requests: read` permissions are required for `secrets.GITHUB_TOKEN`. For more details, see [this](#compatibility-score)
+  - Note: To use this field with the default `${{ github.token }}`, `pull-requests: read` permission is required. If your workflow also checks out the repository or otherwise reads repository contents, `contents: read` may also be needed. For more details, see [this](#compatibility-score)
 - `skip-commit-verification` (boolean)
   - If `true`, then the action will not expect the commits to have a verification signature. **It is required to set this to 'true' in GitHub Enterprise Server**
   - Defaults to `false`
@@ -245,7 +245,6 @@ jobs:
 
     # Following is required for compat-lookup
     permissions:
-      contents: read
       pull-requests: read
 
     steps:

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ This is a simple example of how to use `compat-lookup`.
 name: dependabot-compatibility-score
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   dependabot:

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
 
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
 
     # Following is required for compat-lookup
     permissions:


### PR DESCRIPTION
According to the information below, it states that a PAT is required to use `compat-lookup`.

https://github.com/dependabot/fetch-metadata/blob/4c0bbfe3a642ee5826e71be3cb91cd949dc0a897/README.md#L52

However, based on my investigation, I found that a PAT is not strictly necessary.

I have actually verified that it works using the configuration below.

* Workflow file: https://github.com/sue445/20260220-dependabot-fetch-metadata-poc/blob/a7c09798f8e18aacb0c3fc8aba7ff57cfdeb59d3/.github/workflows/dependabot-compatibility-score.yml#L35
* Job result: https://github.com/sue445/20260220-dependabot-fetch-metadata-poc/actions/runs/23751235579/job/69193606437?pr=4

<details>
  <summary>job full log</summary>

```
2026-03-30T14:53:25.9869047Z Current runner version: '2.333.0'
2026-03-30T14:53:25.9894223Z ##[group]Runner Image Provisioner
2026-03-30T14:53:25.9895048Z Hosted Compute Agent
2026-03-30T14:53:25.9895528Z Version: 20260213.493
2026-03-30T14:53:25.9896097Z Commit: 5c115507f6dd24b8de37d8bbe0bb4509d0cc0fa3
2026-03-30T14:53:25.9896712Z Build Date: 2026-02-13T00:28:41Z
2026-03-30T14:53:25.9897388Z Worker ID: {2ca49f19-8c1b-4fa0-b967-fb08f86151ac}
2026-03-30T14:53:25.9898007Z Azure Region: westus3
2026-03-30T14:53:25.9898490Z ##[endgroup]
2026-03-30T14:53:25.9899906Z ##[group]VM Image
2026-03-30T14:53:25.9900422Z - OS: Linux (x64)
2026-03-30T14:53:25.9900909Z - Source: Docker
2026-03-30T14:53:25.9901427Z - Name: ubuntu:24.04
2026-03-30T14:53:25.9901909Z - Version: 20260323.53.1
2026-03-30T14:53:25.9902367Z ##[endgroup]
2026-03-30T14:53:25.9903879Z ##[group]GITHUB_TOKEN Permissions
2026-03-30T14:53:25.9905713Z Contents: read
2026-03-30T14:53:25.9906183Z Metadata: read
2026-03-30T14:53:25.9906761Z PullRequests: read
2026-03-30T14:53:25.9907358Z ##[endgroup]
2026-03-30T14:53:25.9909506Z Secret source: Dependabot
2026-03-30T14:53:25.9910186Z Prepare workflow directory
2026-03-30T14:53:26.0302088Z Prepare all required actions
2026-03-30T14:53:26.0340507Z Getting action download info
2026-03-30T14:53:26.6137813Z Download action repository 'actions/checkout@v6' (SHA:de0fac2e4500dabe0009e67214ff5f5447ce83dd)
2026-03-30T14:53:26.7857587Z Download action repository 'dependabot/fetch-metadata@v2' (SHA:ffa630c65fa7e0ecfa0625b5ceda64399aea1b36)
2026-03-30T14:53:27.7894709Z Complete job name: dependabot-github-token
2026-03-30T14:53:27.8501203Z ##[group]Run actions/checkout@v6
2026-03-30T14:53:27.8502117Z with:
2026-03-30T14:53:27.8502619Z   repository: sue445/20260220-dependabot-fetch-metadata-poc
2026-03-30T14:53:27.8503835Z   token: ***
2026-03-30T14:53:27.8504218Z   ssh-strict: true
2026-03-30T14:53:27.8504603Z   ssh-user: git
2026-03-30T14:53:27.8504988Z   persist-credentials: true
2026-03-30T14:53:27.8505420Z   clean: true
2026-03-30T14:53:27.8505799Z   sparse-checkout-cone-mode: true
2026-03-30T14:53:27.8506284Z   fetch-depth: 1
2026-03-30T14:53:27.8506649Z   fetch-tags: false
2026-03-30T14:53:27.8507038Z   show-progress: true
2026-03-30T14:53:27.8507432Z   lfs: false
2026-03-30T14:53:27.8507787Z   submodules: false
2026-03-30T14:53:27.8508175Z   set-safe-directory: true
2026-03-30T14:53:27.8509500Z ##[endgroup]
2026-03-30T14:53:28.2107399Z Syncing repository: sue445/20260220-dependabot-fetch-metadata-poc
2026-03-30T14:53:28.2109249Z ##[group]Getting Git version info
2026-03-30T14:53:28.2110353Z Working directory is '/home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc'
2026-03-30T14:53:28.2112432Z [command]/usr/bin/git version
2026-03-30T14:53:28.2255473Z git version 2.53.0
2026-03-30T14:53:28.2329938Z ##[endgroup]
2026-03-30T14:53:28.2336181Z Temporarily overriding HOME='/home/runner/work/_temp/ec1ceaa8-1744-474f-bfc0-d4cf6b0ee5ea' before making global git config changes
2026-03-30T14:53:28.2337770Z Adding repository directory to the temporary git global config as a safe directory
2026-03-30T14:53:28.2341609Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc
2026-03-30T14:53:28.9070282Z Deleting the contents of '/home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc'
2026-03-30T14:53:28.9071788Z ##[group]Initializing the repository
2026-03-30T14:53:28.9073339Z [command]/usr/bin/git init /home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc
2026-03-30T14:53:28.9074645Z hint: Using 'master' as the name for the initial branch. This default branch name
2026-03-30T14:53:28.9075555Z hint: will change to "main" in Git 3.0. To configure the initial branch name
2026-03-30T14:53:28.9076437Z hint: to use in all of your new repositories, which will suppress this warning,
2026-03-30T14:53:28.9077122Z hint: call:
2026-03-30T14:53:28.9077474Z hint:
2026-03-30T14:53:28.9078257Z hint: 	git config --global init.defaultBranch <name>
2026-03-30T14:53:28.9078835Z hint:
2026-03-30T14:53:28.9079374Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
2026-03-30T14:53:28.9080251Z hint: 'development'. The just-created branch can be renamed via this command:
2026-03-30T14:53:28.9080938Z hint:
2026-03-30T14:53:28.9081295Z hint: 	git branch -m <name>
2026-03-30T14:53:28.9081723Z hint:
2026-03-30T14:53:28.9082289Z hint: Disable this message with "git config set advice.defaultBranchName false"
2026-03-30T14:53:28.9083937Z Initialized empty Git repository in /home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc/.git/
2026-03-30T14:53:28.9085925Z [command]/usr/bin/git remote add origin https://github.com/sue445/20260220-dependabot-fetch-metadata-poc
2026-03-30T14:53:28.9087460Z ##[endgroup]
2026-03-30T14:53:28.9088099Z ##[group]Disabling automatic garbage collection
2026-03-30T14:53:28.9088682Z [command]/usr/bin/git config --local gc.auto 0
2026-03-30T14:53:28.9089906Z ##[endgroup]
2026-03-30T14:53:28.9090483Z ##[group]Setting up auth
2026-03-30T14:53:28.9090930Z Removing SSH command configuration
2026-03-30T14:53:28.9091601Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2026-03-30T14:53:28.9093684Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2026-03-30T14:53:28.9095388Z Removing HTTP extra header
2026-03-30T14:53:28.9096346Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2026-03-30T14:53:28.9098645Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2026-03-30T14:53:28.9100734Z Removing includeIf entries pointing to credentials config files
2026-03-30T14:53:28.9101577Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
2026-03-30T14:53:28.9103419Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
2026-03-30T14:53:28.9105919Z [command]/usr/bin/git config --file /home/runner/work/_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
2026-03-30T14:53:28.9108860Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc/.git.path /home/runner/work/_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:28.9112211Z [command]/usr/bin/git config --local includeIf.gitdir:/home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:28.9115494Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:28.9117861Z [command]/usr/bin/git config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:28.9119886Z ##[endgroup]
2026-03-30T14:53:28.9120492Z ##[group]Fetching the repository
2026-03-30T14:53:28.9121719Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f9c8ea9f7654bd6f8a5e02d90d7b2dbc80131907:refs/remotes/pull/4/merge
2026-03-30T14:53:28.9123309Z From https://github.com/sue445/20260220-dependabot-fetch-metadata-poc
2026-03-30T14:53:28.9124129Z  * [new ref]         f9c8ea9f7654bd6f8a5e02d90d7b2dbc80131907 -> pull/4/merge
2026-03-30T14:53:28.9125439Z ##[endgroup]
2026-03-30T14:53:28.9126041Z ##[group]Determining the checkout info
2026-03-30T14:53:28.9126933Z ##[endgroup]
2026-03-30T14:53:28.9127466Z [command]/usr/bin/git sparse-checkout disable
2026-03-30T14:53:28.9128653Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
2026-03-30T14:53:28.9130016Z ##[group]Checking out the ref
2026-03-30T14:53:28.9130637Z [command]/usr/bin/git checkout --progress --force refs/remotes/pull/4/merge
2026-03-30T14:53:28.9131368Z Note: switching to 'refs/remotes/pull/4/merge'.
2026-03-30T14:53:28.9131742Z 
2026-03-30T14:53:28.9132091Z You are in 'detached HEAD' state. You can look around, make experimental
2026-03-30T14:53:28.9133144Z changes and commit them, and you can discard any commits you make in this
2026-03-30T14:53:28.9133978Z state without impacting any branches by switching back to a branch.
2026-03-30T14:53:28.9134449Z 
2026-03-30T14:53:28.9134768Z If you want to create a new branch to retain commits you create, you may
2026-03-30T14:53:28.9135530Z do so (now or later) by using -c with the switch command. Example:
2026-03-30T14:53:28.9135976Z 
2026-03-30T14:53:28.9136170Z   git switch -c <new-branch-name>
2026-03-30T14:53:28.9136473Z 
2026-03-30T14:53:28.9136651Z Or undo this operation with:
2026-03-30T14:53:28.9136934Z 
2026-03-30T14:53:28.9137089Z   git switch -
2026-03-30T14:53:28.9137300Z 
2026-03-30T14:53:28.9137654Z Turn off this advice by setting config variable advice.detachedHead to false
2026-03-30T14:53:28.9138173Z 
2026-03-30T14:53:28.9138915Z HEAD is now at f9c8ea9 Merge b681febd6eb274505c25bc36c477bc7451cd20df into a7c09798f8e18aacb0c3fc8aba7ff57cfdeb59d3
2026-03-30T14:53:28.9141585Z ##[endgroup]
2026-03-30T14:53:28.9142480Z [command]/usr/bin/git log -1 --format=%H
2026-03-30T14:53:28.9143198Z f9c8ea9f7654bd6f8a5e02d90d7b2dbc80131907
2026-03-30T14:53:28.9304588Z ##[group]Run dependabot/fetch-metadata@v2
2026-03-30T14:53:28.9305156Z with:
2026-03-30T14:53:28.9305500Z   compat-lookup: true
2026-03-30T14:53:28.9306082Z   github-token: ***
2026-03-30T14:53:28.9306486Z   skip-commit-verification: false
2026-03-30T14:53:28.9306983Z   skip-verification: false
2026-03-30T14:53:28.9307390Z ##[endgroup]
2026-03-30T14:53:29.7658140Z Parsing Dependabot metadata
2026-03-30T14:53:29.7659168Z ##[group]Outputting metadata for 1 updated dependency
2026-03-30T14:53:29.7659859Z outputs.dependency-names: rspec
2026-03-30T14:53:29.7660374Z outputs.dependency-type: direct:production
2026-03-30T14:53:29.7660976Z outputs.update-type: version-update:semver-patch
2026-03-30T14:53:29.7661570Z outputs.directory: /
2026-03-30T14:53:29.7662015Z outputs.package-ecosystem: bundler
2026-03-30T14:53:29.7662521Z outputs.target-branch: main
2026-03-30T14:53:29.7663385Z outputs.previous-version: 3.13.1
2026-03-30T14:53:29.7663884Z outputs.new-version: 3.13.2
2026-03-30T14:53:29.7664404Z outputs.compatibility-score: 88
2026-03-30T14:53:29.7664890Z outputs.maintainer-changes: false
2026-03-30T14:53:29.7665383Z outputs.dependency-group: 
2026-03-30T14:53:29.7665823Z outputs.alert-state: 
2026-03-30T14:53:29.7666234Z outputs.ghsa-id: 
2026-03-30T14:53:29.7666622Z outputs.cvss: 0
2026-03-30T14:53:29.7667235Z ##[endgroup]
2026-03-30T14:53:29.7757539Z ##[group]Run echo "COMPATIBILITY_SCORE=${COMPATIBILITY_SCORE}"
2026-03-30T14:53:29.7758357Z [36;1mecho "COMPATIBILITY_SCORE=${COMPATIBILITY_SCORE}"[0m
2026-03-30T14:53:29.7809893Z shell: /usr/bin/bash -e {0}
2026-03-30T14:53:29.7810377Z env:
2026-03-30T14:53:29.7810750Z   COMPATIBILITY_SCORE: 88
2026-03-30T14:53:29.7811175Z ##[endgroup]
2026-03-30T14:53:29.7867025Z COMPATIBILITY_SCORE=88
2026-03-30T14:53:29.8064951Z Post job cleanup.
2026-03-30T14:53:30.0198530Z [command]/usr/bin/git version
2026-03-30T14:53:30.0199004Z git version 2.53.0
2026-03-30T14:53:30.0201868Z Temporarily overriding HOME='/home/runner/work/_temp/8b9adf16-2f54-437f-a97f-2f2a2cdf2cfd' before making global git config changes
2026-03-30T14:53:30.0203962Z Adding repository directory to the temporary git global config as a safe directory
2026-03-30T14:53:30.0205484Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc
2026-03-30T14:53:30.0207507Z Removing SSH command configuration
2026-03-30T14:53:30.0208209Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2026-03-30T14:53:30.0210235Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2026-03-30T14:53:30.0212064Z Removing HTTP extra header
2026-03-30T14:53:30.0213292Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2026-03-30T14:53:30.0215704Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2026-03-30T14:53:30.0217853Z Removing includeIf entries pointing to credentials config files
2026-03-30T14:53:30.0218706Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
2026-03-30T14:53:30.0219927Z includeif.gitdir:/home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc/.git.path
2026-03-30T14:53:30.0221476Z includeif.gitdir:/home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc/.git/worktrees/*.path
2026-03-30T14:53:30.0222595Z includeif.gitdir:/github/workspace/.git.path
2026-03-30T14:53:30.0223469Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
2026-03-30T14:53:30.0225577Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc/.git.path
2026-03-30T14:53:30.0227050Z /home/runner/work/_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:30.0229476Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc/.git.path /home/runner/work/_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:30.0232571Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc/.git/worktrees/*.path
2026-03-30T14:53:30.0234344Z /home/runner/work/_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:30.0236826Z [command]/usr/bin/git config --local --unset includeif.gitdir:/home/runner/work/20260220-dependabot-fetch-metadata-poc/20260220-dependabot-fetch-metadata-poc/.git/worktrees/*.path /home/runner/work/_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:30.0239301Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git.path
2026-03-30T14:53:30.0240286Z /github/runner_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:30.0242224Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:30.0245109Z [command]/usr/bin/git config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
2026-03-30T14:53:30.0246513Z /github/runner_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:30.0248764Z [command]/usr/bin/git config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config
2026-03-30T14:53:30.0251005Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
2026-03-30T14:53:30.0253061Z Removing credentials config '/home/runner/work/_temp/git-credentials-4befe366-6e95-47ba-9db4-787112efde16.config'
2026-03-30T14:53:30.0311251Z Cleaning up orphan processes
```

</details>

While using a PAT is still an option, it should be avoided whenever possible for security reasons.

Therefore, I have added an explanation and an example of how to use `secrets.GITHUB_TOKEN`.