### PR TITLE
Dynamically update the tracking tag in action

### DIFF
--- a/.github/workflows/release-move-tracking-tag.yml
+++ b/.github/workflows/release-move-tracking-tag.yml
@@ -4,7 +4,7 @@
 # are resolving immutable actions from packages. Self-hosted runners are still pulling from git tags.
 # So we still need to float this tracking tag. Once Immutable Actions is fully GA'd, then _all_ runners
 # should be resolving from the immutable actions packages, and then we should delete both
-# this workflow AND the `v1`/`v2` git tags.
+# this workflow AND the major version tracking git tags (e.g. `v2`, `v3`, etc).
 
 name: Release - Move Tracking Tag
 
@@ -18,24 +18,11 @@ jobs:
   Move-Tracking-Tag-To-Latest-Release:
     runs-on: ubuntu-latest
 
-    # We have a choice - defensiveness vs convenience:
-    # 1. Be defensive by filtering if the release doesn't look like a normal
-    #    version, or if it's a patch release to an older version... the logic
-    #    gets tricky quickly. Easiest way to be 100% sure is stop running this
-    #    on `release` and instead require a human to manually run this workflow
-    #    after they tag a release.
-    # 2. Minimize the upfront hassle by assuming every release is a normal
-    #    version release and the latest one. Today both are resoundingly true
-    #    as this repo isn't that active/busy, so we don't worry about
-    #    multiple release branches, pre-releases, etc.
-    #
-    # For now I've gone with option 2, as it is much more convenient and if we
-    # typo something during a release it's easy to fix by immediately tagging a
-    # correct release. And if we don't notice the typo, well, in that case
-    # requiring a human to manually run the workflow wouldn't have protected us
-    # either, we'd have had to filter by only things that look like versions.
-    # Anyway, for now this is good enough, and if it gets to be a problem down
-    # the road we increase the robustness of this.
+    # This workflow dynamically extracts the major version from the release
+    # tag (e.g. `v3.0.0` -> `v3`) and moves the corresponding tracking tag.
+    # It assumes every release tag follows the `vN.Y.Z` format. If a release
+    # is tagged with something unexpected, the "Extract major version" step
+    # will fail with a clear error rather than silently doing the wrong thing.
 
     steps:
       - name: Generate token
@@ -49,12 +36,24 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
 
+      - name: Extract major version from release tag
+        id: extract_major
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          MAJOR_TAG=$(echo "$TAG" | grep -oP '^v\d+')
+          if [[ -z "$MAJOR_TAG" ]]; then
+            echo "::error::Could not extract major version from release tag '$TAG'. Expected format: vN.Y.Z"
+            exit 1
+          fi
+          echo "major_tag=$MAJOR_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Move the tracking tag
-        run: git tag -f v2
+        run: git tag -f ${{ steps.extract_major.outputs.major_tag }}
 
       - name: Push the new tag value back to the repo
-        run: git push -f origin refs/tags/v2
+        run: git push -f origin refs/tags/${{ steps.extract_major.outputs.major_tag }}
 
       - name: Set summary
         run: |
-          echo ":rocket: Successfully moved the \`v2\` tag to point at release: ${{ github.event.release.name }} with SHA: \`$GITHUB_SHA\`." >> $GITHUB_STEP_SUMMARY
+          echo ":rocket: Successfully moved the \`${{ steps.extract_major.outputs.major_tag }}\` tag to point at release: ${{ github.event.release.name }} with SHA: \`$GITHUB_SHA\`." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
We recently [released version 3 of this action](https://github.com/dependabot/fetch-metadata/pull/686). That exposed that the major version tracking hasn't automatically updated, so [now `v2` tag is pointing to `v3.0.0`](https://github.com/dependabot/fetch-metadata/actions/runs/23613105416), a clear mistake.

Reading the comments from when the workflow to move the tracking was last updated (#506), we chose to go for speed when moving from v1 -> v2. This PR updates the workflow to extract the major version dynamically, so we won't have this issue again.

This does bring up a follow up, which is what's the state of immutable releases. Perhaps we can get rid of these actions all together.

- Fixes https://github.com/dependabot/fetch-metadata/issues/688
