### PR TITLE
fix: resolve update-type null for Python, Composer, and Terraform PRs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31454,9 +31454,11 @@ function branchNameToDirectoryName(chunks, delimiter, updatedDependencies, depen
   });
   return `/${chunks.slice(sliceStart, sliceEnd).join("/")}`;
 }
-async function parse3(commitMessage, body, branchName, mainBranch, lookup, getScore) {
+async function parse3(commitMessage, body, branchName, mainBranch, lookup, getScore, title) {
+  const updateRegex = /\b[Uu]pdate .* requirement from \S*? ?(?<from>v?\d\S*) to \S*? ?(?<to>v?\d\S*)/;
   const bumpFragment = commitMessage.match(/^Bumps .* from (?<from>v?\d[^ ]*) to (?<to>v?\d[^ ]*)\.$/m);
-  const updateFragment = commitMessage.match(/^Update .* requirement from \S*? ?(?<from>v?\d\S*) to \S*? ?(?<to>v?\d\S*)/m);
+  const updateFragment = commitMessage.split("\n")[0].match(updateRegex);
+  const titleUpdateFragment = !bumpFragment && !updateFragment && title ? title.match(updateRegex) : null;
   const yamlFragment = commitMessage.match(/^-{3}\n(?<dependencies>[\S|\s]*?)\n^\.{3}\n/m);
   const groupName = commitMessage.match(/dependency-group:\s(?<name>\S*)/m);
   const newMaintainer = !!body.match(/Maintainer changes/m);
@@ -31466,8 +31468,8 @@ async function parse3(commitMessage, body, branchName, mainBranch, lookup, getSc
     const data = YAML.parse(yamlFragment.groups.dependencies);
     const delim = branchName[10];
     const chunks = branchName.split(delim);
-    const prev = bumpFragment?.groups?.from ?? (updateFragment?.groups?.from ?? "");
-    const next = bumpFragment?.groups?.to ?? (updateFragment?.groups?.to ?? "");
+    const prev = bumpFragment?.groups?.from ?? updateFragment?.groups?.from ?? titleUpdateFragment?.groups?.from ?? "";
+    const next = bumpFragment?.groups?.to ?? updateFragment?.groups?.to ?? titleUpdateFragment?.groups?.to ?? "";
     const dependencyGroup = groupName?.groups?.name ?? "";
     if (data["updated-dependencies"]) {
       const updatedVersions = parseMetadataLinks(commitMessage);
@@ -31624,6 +31626,10 @@ function getBody(context3) {
   const { pull_request: pr } = context3.payload;
   return pr?.body || "";
 }
+function getTitle(context3) {
+  const { pull_request: pr } = context3.payload;
+  return pr?.title || "";
+}
 
 // src/main.ts
 async function run() {
@@ -31639,6 +31645,7 @@ async function run() {
     const commitMessage = await getMessage(githubClient, context2, getBooleanInput("skip-commit-verification"), getBooleanInput("skip-verification"));
     const branchNames = getBranchNames(context2);
     const body = getBody(context2);
+    const title = getTitle(context2);
     let alertLookup;
     if (getInput("alert-lookup")) {
       alertLookup = (name, version, directory) => getAlert(name, version, directory, githubClient, context2);
@@ -31646,7 +31653,7 @@ async function run() {
     const scoreLookup = getInput("compat-lookup") ? getCompatibility : void 0;
     if (commitMessage) {
       info("Parsing Dependabot metadata");
-      const updatedDependencies = await parse3(commitMessage, body, branchNames.headName, branchNames.baseName, alertLookup, scoreLookup);
+      const updatedDependencies = await parse3(commitMessage, body, branchNames.headName, branchNames.baseName, alertLookup, scoreLookup, title);
       if (updatedDependencies.length > 0) {
         set(updatedDependencies);
       } else {

--- a/src/dependabot/update_metadata.test.ts
+++ b/src/dependabot/update_metadata.test.ts
@@ -585,6 +585,112 @@ test('it handles pip requirement updates with directory suffix', async () => {
   expect(updatedDependencies[0].newVersion).toEqual('1.42.86')
 })
 
+test('it handles Composer updates where commit message lacks versions but PR title has them', async () => {
+  const commitMessage =
+    'Updates the requirements on [rector/rector](https://github.com/rectorphp/rector) to permit the latest version.\n' +
+    '- [Release notes](https://github.com/rectorphp/rector/releases)\n' +
+    '- [Changelog](https://github.com/rectorphp/rector/blob/main/CHANGELOG.md)\n' +
+    '\n' +
+    '---\n' +
+    'updated-dependencies:\n' +
+    '- dependency-name: rector/rector\n' +
+    '  dependency-type: direct:development\n' +
+    '...\n' +
+    '\n' +
+    'Signed-off-by: dependabot[bot] <support@github.com>'
+  const title = 'Update rector/rector requirement from ^1.2 to ^2.0'
+  const updatedDependencies = await updateMetadata.parse(commitMessage, '', 'dependabot/composer/rector/rector-2.0.4', 'main', undefined, undefined, title)
+
+  expect(updatedDependencies).toHaveLength(1)
+  expect(updatedDependencies[0].dependencyName).toEqual('rector/rector')
+  expect(updatedDependencies[0].updateType).toEqual('version-update:semver-major')
+  expect(updatedDependencies[0].prevVersion).toEqual('1.2')
+  expect(updatedDependencies[0].newVersion).toEqual('2.0')
+})
+
+test('it handles Terraform updates with chore(deps) commit prefix', async () => {
+  const commitMessage =
+    'chore(deps): Update hashicorp/aws requirement from ~> 5.90 to ~> 5.92 in /terraform/test/region/us-west-2\n' +
+    '\n' +
+    '---\n' +
+    'updated-dependencies:\n' +
+    '- dependency-name: hashicorp/aws\n' +
+    '  dependency-type: direct:production\n' +
+    '...\n' +
+    '\n' +
+    'Signed-off-by: dependabot[bot] <support@github.com>'
+  const updatedDependencies = await updateMetadata.parse(commitMessage, '', 'dependabot/terraform/terraform/test/region/us-west-2/hashicorp/aws-5.92', 'main')
+
+  expect(updatedDependencies).toHaveLength(1)
+  expect(updatedDependencies[0].dependencyName).toEqual('hashicorp/aws')
+  expect(updatedDependencies[0].prevVersion).toEqual('5.90')
+  expect(updatedDependencies[0].newVersion).toEqual('5.92')
+  expect(updatedDependencies[0].updateType).toEqual('version-update:semver-minor')
+})
+
+test('it handles Python pip updates where commit lacks versions and PR title is used as fallback', async () => {
+  const commitMessage =
+    'Updates the requirements on [faker](https://github.com/joke2k/faker) to permit the latest version.\n' +
+    '\n' +
+    '---\n' +
+    'updated-dependencies:\n' +
+    '- dependency-name: faker\n' +
+    '  dependency-type: direct:production\n' +
+    '...\n' +
+    '\n' +
+    'Signed-off-by: dependabot[bot] <support@github.com>'
+  const title = 'Update faker requirement from ~=35.0 to ~=35.2 in /asset_api'
+  const updatedDependencies = await updateMetadata.parse(commitMessage, '', 'dependabot/pip/asset_api/faker-35.2', 'main', undefined, undefined, title)
+
+  expect(updatedDependencies).toHaveLength(1)
+  expect(updatedDependencies[0].dependencyName).toEqual('faker')
+  expect(updatedDependencies[0].prevVersion).toEqual('35.0')
+  expect(updatedDependencies[0].newVersion).toEqual('35.2')
+  expect(updatedDependencies[0].updateType).toEqual('version-update:semver-minor')
+})
+
+test('it handles Python pip updates with ~= prefix in PR title for boto3', async () => {
+  const commitMessage =
+    'Updates the requirements on [boto3](https://github.com/boto/boto3) to permit the latest version.\n' +
+    '\n' +
+    '---\n' +
+    'updated-dependencies:\n' +
+    '- dependency-name: boto3\n' +
+    '  dependency-type: direct:production\n' +
+    '...\n' +
+    '\n' +
+    'Signed-off-by: dependabot[bot] <support@github.com>'
+  const title = 'Update boto3 requirement from ~=1.42.73 to ~=1.42.88 in /services/search'
+  const updatedDependencies = await updateMetadata.parse(commitMessage, '', 'dependabot/pip/services/search/boto3-1.42.88', 'main', undefined, undefined, title)
+
+  expect(updatedDependencies).toHaveLength(1)
+  expect(updatedDependencies[0].dependencyName).toEqual('boto3')
+  expect(updatedDependencies[0].prevVersion).toEqual('1.42.73')
+  expect(updatedDependencies[0].newVersion).toEqual('1.42.88')
+  expect(updatedDependencies[0].updateType).toEqual('version-update:semver-patch')
+})
+
+test('it prefers commit message versions over PR title versions', async () => {
+  const commitMessage =
+    'Update boto3 requirement from <=1.42.76 to <=1.42.86 in /app\n' +
+    '\n' +
+    'Updates the requirements on [boto3](https://github.com/boto/boto3) to permit the latest version.\n' +
+    '\n' +
+    '---\n' +
+    'updated-dependencies:\n' +
+    '- dependency-name: boto3\n' +
+    '  dependency-type: direct:production\n' +
+    '...\n' +
+    '\n' +
+    'Signed-off-by: dependabot[bot] <support@github.com>'
+  const title = 'Update boto3 requirement from <=1.42.00 to <=1.42.99 in /app'
+  const updatedDependencies = await updateMetadata.parse(commitMessage, '', 'dependabot/pip/app/boto3-1.42.86', 'main', undefined, undefined, title)
+
+  expect(updatedDependencies).toHaveLength(1)
+  expect(updatedDependencies[0].prevVersion).toEqual('1.42.76')
+  expect(updatedDependencies[0].newVersion).toEqual('1.42.86')
+})
+
 test('it handles duplicate dependency names in metadata links without mixing versions', async () => {
   const commitMessage =
     'Bumps the production group with 2 updates\n' +

--- a/src/dependabot/update_metadata.ts
+++ b/src/dependabot/update_metadata.ts
@@ -66,9 +66,11 @@ function branchNameToDirectoryName (chunks: string[], delimiter: string, updated
   return `/${chunks.slice(sliceStart, sliceEnd).join('/')}`
 }
 
-export async function parse (commitMessage: string, body: string, branchName: string, mainBranch: string, lookup?: alertLookup, getScore?: scoreLookup): Promise<Array<updatedDependency>> {
+export async function parse (commitMessage: string, body: string, branchName: string, mainBranch: string, lookup?: alertLookup, getScore?: scoreLookup, title?: string): Promise<Array<updatedDependency>> {
+  const updateRegex = /\b[Uu]pdate .* requirement from \S*? ?(?<from>v?\d\S*) to \S*? ?(?<to>v?\d\S*)/
   const bumpFragment = commitMessage.match(/^Bumps .* from (?<from>v?\d[^ ]*) to (?<to>v?\d[^ ]*)\.$/m)
-  const updateFragment = commitMessage.match(/^Update .* requirement from \S*? ?(?<from>v?\d\S*) to \S*? ?(?<to>v?\d\S*)/m)
+  const updateFragment = commitMessage.split('\n')[0].match(updateRegex)
+  const titleUpdateFragment = (!bumpFragment && !updateFragment && title) ? title.match(updateRegex) : null
   const yamlFragment = commitMessage.match(/^-{3}\n(?<dependencies>[\S|\s]*?)\n^\.{3}\n/m)
   const groupName = commitMessage.match(/dependency-group:\s(?<name>\S*)/m)
   const newMaintainer = !!body.match(/Maintainer changes/m)
@@ -81,8 +83,8 @@ export async function parse (commitMessage: string, body: string, branchName: st
     // Since we are on the `dependabot` branch (9 letters), the 10th letter in the branch name is the delimiter
     const delim = branchName[10]
     const chunks = branchName.split(delim)
-    const prev = bumpFragment?.groups?.from ?? (updateFragment?.groups?.from ?? '')
-    const next = bumpFragment?.groups?.to ?? (updateFragment?.groups?.to ?? '')
+    const prev = bumpFragment?.groups?.from ?? updateFragment?.groups?.from ?? titleUpdateFragment?.groups?.from ?? ''
+    const next = bumpFragment?.groups?.to ?? updateFragment?.groups?.to ?? titleUpdateFragment?.groups?.to ?? ''
     const dependencyGroup = groupName?.groups?.name ?? ''
 
     if (data['updated-dependencies']) {

--- a/src/dependabot/util.ts
+++ b/src/dependabot/util.ts
@@ -24,3 +24,8 @@ export function getBody (context: Context): string {
   const { pull_request: pr } = context.payload
   return pr?.body || ''
 }
+
+export function getTitle (context: Context): string {
+  const { pull_request: pr } = context.payload
+  return pr?.title || ''
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ export async function run (): Promise<void> {
     const commitMessage = await verifiedCommits.getMessage(githubClient, github.context, core.getBooleanInput('skip-commit-verification'), core.getBooleanInput('skip-verification'))
     const branchNames = util.getBranchNames(github.context)
     const body = util.getBody(github.context)
+    const title = util.getTitle(github.context)
     let alertLookup: updateMetadata.alertLookup | undefined
     if (core.getInput('alert-lookup')) {
       alertLookup = (name, version, directory) => verifiedCommits.getAlert(name, version, directory, githubClient, github.context)
@@ -35,7 +36,7 @@ export async function run (): Promise<void> {
       // Parse metadata
       core.info('Parsing Dependabot metadata')
 
-      const updatedDependencies = await updateMetadata.parse(commitMessage, body, branchNames.headName, branchNames.baseName, alertLookup, scoreLookup)
+      const updatedDependencies = await updateMetadata.parse(commitMessage, body, branchNames.headName, branchNames.baseName, alertLookup, scoreLookup, title)
 
       if (updatedDependencies.length > 0) {
         output.set(updatedDependencies)


### PR DESCRIPTION
## Summary

Fixes #499 — `update-type` is returned as `null` for certain dependency PRs.

**Two root causes, two fixes:**

1. **Relaxed `updateFragment` regex** — changed `^Update` to `\b[Uu]pdate` and applied it to the first line of the commit message only. This handles custom commit prefixes like `chore(deps): update hashicorp/aws requirement from ~> 5.80.0 to ~> 5.82.2` ([reported here](https://github.com/dependabot/fetch-metadata/issues/499#issuecomment-2557193093)) while avoiding false positives from changelog text in the commit body.

2. **PR title fallback** — when the commit message lacks version numbers entirely (e.g., *"Updates the requirements on X to permit the latest version."*), the `parse` function now falls back to extracting versions from the PR title. This addresses the `rector/rector` case from the [original report](https://github.com/dependabot/fetch-metadata/issues/499#issue-2187293989) and the `faker` case [reported here](https://github.com/dependabot/fetch-metadata/issues/499#issuecomment-2629019454).

## Verified scenarios

| Scenario | Ecosystem | Before | After |
|----------|-----------|--------|-------|
| `rector/rector` ^1.2 to ^2.0 | Composer | `null` | `semver-major` |
| `hashicorp/aws` with `chore(deps):` prefix | Terraform | `null` | `semver-minor` |
| `faker` ~=35.0 to ~=35.2 in /asset_api | Python/pip | `null` | `semver-minor` |
| `boto3` ~=1.42.73 to ~=1.42.88 | Python/pip | `null` | `semver-patch` |

## Design notes

- **First-line matching for commit messages**: `updateFragment` previously used the `m` (multiline) flag, matching `^Update` on any line of the commit message. The new code matches only the first line to avoid false positives from changelog/release note text in the commit body. All existing tests pass — Dependabot always puts the "Update X requirement from..." text on the first line. If there's an ecosystem where this text appears on line 2+, the PR title fallback would still catch it.
- **`title` parameter position**: `title` is appended as the last parameter of `parse()` to minimize churn on existing callers. Happy to restructure (e.g., options object) if preferred.

## Test plan

- [x] All 25 existing + new tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Regression test: commit message versions take priority over title when both are present
- [ ] Verify against real Dependabot PRs in a downstream repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)