### PR TITLE
fix: handle Docker digest-only updates

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31660,8 +31660,10 @@ async function parse3(commitMessage, body, branchName, mainBranch, lookup, getSc
         nameCounters.set(dependencyName, nameIndex + 1);
         const updatedVersionList = updatedVersions.get(dependencyName);
         const updatedVersion = updatedVersionList?.[nameIndex];
-        const lastVersion = updatedVersion?.prevVersion || (index === 0 ? prev : "");
-        const nextVersion = dependency["dependency-version"] || updatedVersion?.newVersion || (index === 0 ? next : "");
+        const dependencyVersion = dependency["dependency-version"];
+        const isDockerDigestOnlyUpdate = chunks[1] === "docker" && !!dependencyVersion && !dependency["update-type"] && isMarkdownCodeSpan(updatedVersion?.prevVersion) && isMarkdownCodeSpan(updatedVersion?.newVersion);
+        const lastVersion = isDockerDigestOnlyUpdate ? dependencyVersion : updatedVersion?.prevVersion || (index === 0 ? prev : "");
+        const nextVersion = dependencyVersion || updatedVersion?.newVersion || (index === 0 ? next : "");
         const updateType = dependency["update-type"] || calculateUpdateType(lastVersion, nextVersion);
         return {
           dependencyName: dependency["dependency-name"],
@@ -31703,6 +31705,9 @@ function parseMetadataLinks(commitMessage) {
     }
   }
   return updates;
+}
+function isMarkdownCodeSpan(value) {
+  return !!value && value.startsWith("`") && value.endsWith("`");
 }
 function calculateUpdateType(lastVersion, nextVersion) {
   if (!lastVersion || !nextVersion || lastVersion === nextVersion) {

--- a/src/dependabot/update_metadata.test.ts
+++ b/src/dependabot/update_metadata.test.ts
@@ -536,6 +536,31 @@ updated-dependencies:
   expect(updatedDependencies[1].newVersion).toEqual('1.27.1')
 })
 
+test('it handles Docker digest-only updates without classifying the tag as changed', async () => {
+  const commitMessage = `Bumps the docker group with 1 update: shawntoffel/dependabot-digest-test.
+
+
+Updates \`shawntoffel/dependabot-digest-test\` from \`e1b523f\` to \`5fdf1f3\`
+
+---
+updated-dependencies:
+- dependency-name: shawntoffel/dependabot-digest-test
+  dependency-version: 1.0-alpine3.24
+  dependency-type: direct:production
+  dependency-group: docker
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+`
+  const updatedDependencies = await updateMetadata.parse(commitMessage, '', 'dependabot/docker/docker-2b208d09c0', 'master')
+
+  expect(updatedDependencies).toHaveLength(1)
+  expect(updatedDependencies[0].dependencyName).toEqual('shawntoffel/dependabot-digest-test')
+  expect(updatedDependencies[0].updateType).toEqual('')
+  expect(updatedDependencies[0].prevVersion).toEqual('1.0-alpine3.24')
+  expect(updatedDependencies[0].newVersion).toEqual('1.0-alpine3.24')
+})
+
 test('it handles new versions from YAML', async () => {
   const commitMessage = `Bump the non-breaking group in /log4j-parent with 2 updates
 

--- a/src/dependabot/update_metadata.ts
+++ b/src/dependabot/update_metadata.ts
@@ -98,8 +98,15 @@ export async function parse (commitMessage: string, body: string, branchName: st
         nameCounters.set(dependencyName, nameIndex + 1)
         const updatedVersionList = updatedVersions.get(dependencyName)
         const updatedVersion = updatedVersionList?.[nameIndex]
-        const lastVersion = updatedVersion?.prevVersion || (index === 0 ? prev : '')
-        const nextVersion = dependency['dependency-version'] || updatedVersion?.newVersion || (index === 0 ? next : '')
+        const dependencyVersion = dependency['dependency-version']
+        // Digest-only Docker updates code-format the digests while dependency-version contains the unchanged tag.
+        const isDockerDigestOnlyUpdate = chunks[1] === 'docker' &&
+          !!dependencyVersion &&
+          !dependency['update-type'] &&
+          isMarkdownCodeSpan(updatedVersion?.prevVersion) &&
+          isMarkdownCodeSpan(updatedVersion?.newVersion)
+        const lastVersion = isDockerDigestOnlyUpdate ? dependencyVersion : updatedVersion?.prevVersion || (index === 0 ? prev : '')
+        const nextVersion = dependencyVersion || updatedVersion?.newVersion || (index === 0 ? next : '')
         const updateType = dependency['update-type'] || calculateUpdateType(lastVersion, nextVersion)
         return {
           dependencyName: dependency['dependency-name'],
@@ -154,6 +161,10 @@ function parseMetadataLinks(commitMessage: string): Map<string, dependencyVersio
     }
   }
   return updates
+}
+
+function isMarkdownCodeSpan (value?: string): boolean {
+  return !!value && value.startsWith('`') && value.endsWith('`')
 }
 
 export function calculateUpdateType (lastVersion: string, nextVersion: string) {


### PR DESCRIPTION
## Summary

- recognize Docker digest-only metadata without treating a digest as a semantic version
- report the unchanged Docker tag as both previous and new version when no explicit update type exists
- cover the reported commit metadata and regenerate the checked-in action bundle

## Root cause

Dependabot code-formats the old and new digests in the metadata link while `dependency-version` contains the unchanged image tag. The parser combined the old digest with the tag and incorrectly calculated a major version update.

## Validation

- `npm test -- --runInBand` (57 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build` (two consecutive builds produced identical output)
- `git diff --check`

Fixes #726
