### PR TITLE
fix: use current PR head commit metadata

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31548,7 +31548,8 @@ async function getMessage(client, context3, skipCommitVerification = false, skip
     repo: context3.repo.repo,
     pull_number: pr.number
   });
-  const { commit, author } = commits[0];
+  const headCommit = pr.head?.sha ? commits.find(({ sha }) => sha === pr.head.sha) : void 0;
+  const { commit, author } = headCommit ?? commits[0];
   if (!skipVerification && author?.login !== DEPENDABOT_LOGIN) {
     warning(
       "It looks like this PR was not created by Dependabot, refusing to proceed."

--- a/src/dependabot/verified_commits.test.ts
+++ b/src/dependabot/verified_commits.test.ts
@@ -149,6 +149,38 @@ test('it returns the commit message for a PR authored exclusively by Dependabot 
   expect(await getMessage(mockGitHubClient, mockGitHubPullContext())).toEqual('Bump lodash from 1.0.0 to 2.0.0')
 })
 
+test('it returns the current head commit message when a Dependabot PR has been updated', async () => {
+  nock('https://api.github.com').get('/repos/dependabot/dependabot/pulls/101/commits')
+    .reply(200, [
+      {
+        sha: 'initial-commit',
+        author: {
+          login: 'dependabot[bot]'
+        },
+        commit: {
+          message: 'Bump lodash from 1.0.0 to 2.0.0',
+          verification: {
+            verified: true
+          }
+        }
+      },
+      {
+        sha: 'updated-commit',
+        author: {
+          login: 'dependabot[bot]'
+        },
+        commit: {
+          message: 'Bump lodash from 1.0.0 to 3.0.0',
+          verification: {
+            verified: true
+          }
+        }
+      }
+    ])
+
+  expect(await getMessage(mockGitHubClient, mockGitHubPullContext('dependabot[bot]', 'updated-commit'))).toEqual('Bump lodash from 1.0.0 to 3.0.0')
+})
+
 const query = '{"query":"\\n     {\\n       repository(owner: \\"dependabot\\", name: \\"dependabot\\") { \\n         vulnerabilityAlerts(first: 100) {\\n           nodes {\\n             vulnerableManifestFilename\\n             vulnerableManifestPath\\n             vulnerableRequirements\\n             state\\n             securityVulnerability { \\n               package { name } \\n             }\\n             securityAdvisory { \\n              cvss { score }\\n              ghsaId \\n             }\\n           }\\n         }\\n       }\\n     }"}'
 
 const response = {
@@ -313,11 +345,12 @@ function mockGitHubOtherContext (): Context {
   return ctx
 }
 
-function mockGitHubPullContext (author = 'dependabot[bot]'): Context {
+function mockGitHubPullContext (author = 'dependabot[bot]', headSha?: string): Context {
   const ctx = new Context()
   ctx.payload = {
     pull_request: {
       number: 101,
+      ...(headSha ? { head: { sha: headSha } } : {}),
       user: {
         login: author
       }

--- a/src/dependabot/verified_commits.ts
+++ b/src/dependabot/verified_commits.ts
@@ -35,7 +35,10 @@ export async function getMessage (client: InstanceType<typeof GitHub>, context: 
     pull_number: pr.number
   })
 
-  const { commit, author } = commits[0]
+  const headCommit = pr.head?.sha
+    ? commits.find(({ sha }) => sha === pr.head.sha)
+    : undefined
+  const { commit, author } = headCommit ?? commits[0]
 
   if (!skipVerification && author?.login !== DEPENDABOT_LOGIN) {
     // TODO: Promote to setFailed


### PR DESCRIPTION
# fix: use current PR head commit metadata

## Summary

When Dependabot updates an existing pull request, its commit list includes the original metadata commit before the current head commit. The action previously always parsed the first commit, so it could expose metadata for the old update. This change selects the commit matching the pull request's current head SHA.

Fixes #728

## Changes

- Read metadata from the pull request's current head commit when it is present in the commit list.
- Add regression coverage for updated Dependabot pull requests.
- Regenerate the committed action bundle.

## Testing

- `sandbox-run "npm ci && npm test -- --runInBand"` — Jest completed successfully: 4 suites and 57 tests passed. The sandbox command returned exit code 1 because the action's intentional missing-token test writes an error command to stdout.
- `sandbox-run "npm ci && npm run typecheck && npm run lint && npm run build && git diff --exit-code -- dist/index.js"` — typecheck, lint, and build completed successfully. The final bundle-diff check could not run because `git` is unavailable in the sandbox (exit code 127); the generated `dist/index.js` was inspected and committed.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
