### PR TITLE
Build dist for all npm dependency updates

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -16,7 +16,6 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     # Map the step output to a job output for subsequent jobs
     outputs:
-      dependency-type: ${{ steps.dependabot-metadata.outputs.dependency-type }}
       package-ecosystem: ${{ steps.dependabot-metadata.outputs.package-ecosystem }}
     steps:
       - uses: actions/checkout@v7
@@ -31,8 +30,8 @@ jobs:
     permissions:
       contents: write
 
-    # We only need to build the dist/ folder if the PR relates a production NPM dependency, otherwise we don't expect changes.
-    if: needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn' && needs.fetch-dependabot-metadata.outputs.dependency-type == 'direct:production'
+    # Any npm dependency can affect the bundle, including indirect dependencies and build tooling.
+    if: needs.fetch-dependabot-metadata.outputs.package-ecosystem == 'npm_and_yarn'
     steps:
       - name: Generate token
         id: generate_token
@@ -59,8 +58,14 @@ jobs:
       - name: Check in any change to dist/
         run: |
           git add dist/
+
+          if git diff --cached --quiet -- dist/; then
+            echo "The dependency update does not affect dist/"
+            exit 0
+          fi
+
           # Specifying the full email allows the avatar to show up: https://github.com/orgs/community/discussions/26560
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "[dependabot skip] Update dist/ with build changes" || exit 0
+          git commit -m "[dependabot skip] Update dist/ with build changes"
           git push


### PR DESCRIPTION
Rebuild the checked-in action bundle for every npm Dependabot update, including indirect dependencies and development build tooling.

The existing workflow only runs for `direct:production` updates. That misses updates such as `undici` in #734, even though the transitive dependency is included in `dist/index.js`. Dependency classification is not a reliable proxy for bundle impact; development tooling such as esbuild can also change generated output.

The workflow now uses the build output as the selector:

- Run for every `npm_and_yarn` Dependabot PR.
- Stage the rebuilt `dist/` directory.
- Exit without a commit or push when `dist/` is unchanged.
- Commit and push only when the bundle actually changed.

The explicit staged-diff check also avoids suppressing genuine `git commit` errors with `git commit ... || exit 0`.

This matches the approach used by `github/dependabot-action`.

Validation:
- Workflow YAML parses successfully.
- A clean rebuild from `main` produces no staged change and takes the no-op path.
- Rebuilding PR #734 detects the expected `dist/index.js` change and takes the commit path.
- `npm run typecheck`
- `npm run lint`
- `git diff --check`