### PR TITLE
Check out Dependabot branch before updating dist

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -42,6 +42,8 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
+          # Check out the source branch so the generated commit can be pushed back to the PR.
+          ref: ${{ github.event.pull_request.head.ref }}
           # Check out using an app token so any pushed changes will trigger checkruns
           token: ${{ steps.generate_token.outputs.token }}
 


### PR DESCRIPTION
Fix the automatic `dist` commit added by #741.

On pull request workflows, `actions/checkout` defaults to GitHub's synthetic merge ref. The build successfully generated and committed the updated bundle for #734, but `git push` then failed because the checkout was in detached HEAD state:

```text
[detached HEAD 6e87458] [dependabot skip] Update dist/ with build changes
fatal: You are not currently on a branch.
```

Check out `github.event.pull_request.head.ref` in the write-enabled job so the generated commit is based on and pushed back to the Dependabot source branch. This matches the checkout used by `github/dependabot-action` for the same workflow pattern.

Validation:
- workflow YAML parses
- `git diff --check`
- `npm run lint`

After this merges, #734 needs to rebase once more to trigger the corrected workflow.